### PR TITLE
First attempt at genericizing data source

### DIFF
--- a/python-package/examples/app.py
+++ b/python-package/examples/app.py
@@ -4,6 +4,7 @@ from seaborn import load_dataset
 from shiny import App, render, ui
 
 import querychat
+from querychat.datasource import DataFrameSource
 
 titanic = load_dataset("titanic")
 
@@ -14,8 +15,7 @@ with open(Path(__file__).parent / "data_description.md", "r") as f:
 
 # 1. Configure querychat
 querychat_config = querychat.init(
-    titanic,
-    "titanic",
+    DataFrameSource(titanic, "titanic"),
     greeting=greeting,
     data_description=data_desc,
 )

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -23,6 +23,11 @@ dependencies = [
     "chevron",
 ]
 
+[project.optional-dependencies]
+sqlalchemy = [
+    "sqlalchemy>=2.0.0",  # Using 2.0+ for improved type hints and API
+]
+
 [project.urls]
 Homepage = "https://github.com/posit-dev/querychat"
 Issues = "https://github.com/posit-dev/querychat/issues"

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "htmltools",
     "chatlas",
     "narwhals",
+    "chevron",
 ]
 
 [project.urls]

--- a/python-package/querychat/datasource.py
+++ b/python-package/querychat/datasource.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from typing import Protocol
+import pandas as pd
+import duckdb
+import sqlite3
+import narwhals as nw
+
+
+class DataSource(Protocol):
+    def get_schema(self) -> str:
+        """Return schema information about the table as a string.
+
+        Returns:
+            A string containing the schema information in a format suitable for
+            prompting an LLM about the data structure
+        """
+        ...
+
+    def execute_query(self, query: str) -> pd.DataFrame:
+        """Execute SQL query and return results as DataFrame.
+
+        Args:
+            query: SQL query to execute
+
+        Returns:
+            Query results as a pandas DataFrame
+        """
+        ...
+
+    def get_data(self) -> pd.DataFrame:
+        """Return the unfiltered data as a DataFrame.
+
+        Returns:
+            The complete dataset as a pandas DataFrame
+        """
+        ...
+
+
+class DataFrameSource:
+    """A DataSource implementation that wraps a pandas DataFrame using DuckDB."""
+
+    def __init__(self, df: pd.DataFrame, table_name: str):
+        """Initialize with a pandas DataFrame.
+
+        Args:
+            df: The DataFrame to wrap
+            table_name: Name of the table in SQL queries
+        """
+        self._conn = duckdb.connect(database=":memory:")
+        self._df = df
+        self._table_name = table_name
+        self._conn.register(table_name, df)
+
+    def get_schema(self, categorical_threshold: int = 10) -> str:
+        """Generate schema information from DataFrame.
+
+        Args:
+            table_name: Name to use for the table in schema description
+            categorical_threshold: Maximum number of unique values for a text column
+                                to be considered categorical
+
+        Returns:
+            String describing the schema
+        """
+        ndf = nw.from_native(self._df)
+
+        schema = [f"Table: {self._table_name}", "Columns:"]
+
+        for column in ndf.columns:
+            # Map pandas dtypes to SQL-like types
+            dtype = ndf[column].dtype
+            if dtype.is_integer():
+                sql_type = "INTEGER"
+            elif dtype.is_float():
+                sql_type = "FLOAT"
+            elif dtype == nw.Boolean:
+                sql_type = "BOOLEAN"
+            elif dtype == nw.Datetime:
+                sql_type = "TIME"
+            elif dtype == nw.Date:
+                sql_type = "DATE"
+            else:
+                sql_type = "TEXT"
+
+            column_info = [f"- {column} ({sql_type})"]
+
+            # For TEXT columns, check if they're categorical
+            if sql_type == "TEXT":
+                unique_values = ndf[column].drop_nulls().unique()
+                if unique_values.len() <= categorical_threshold:
+                    categories = unique_values.to_list()
+                    categories_str = ", ".join([f"'{c}'" for c in categories])
+                    column_info.append(f"  Categorical values: {categories_str}")
+
+            # For numeric columns, include range
+            elif sql_type in ["INTEGER", "FLOAT", "DATE", "TIME"]:
+                rng = ndf[column].min(), ndf[column].max()
+                if rng[0] is None and rng[1] is None:
+                    column_info.append("  Range: NULL to NULL")
+                else:
+                    column_info.append(f"  Range: {rng[0]} to {rng[1]}")
+
+            schema.extend(column_info)
+
+        return "\n".join(schema)
+
+    def execute_query(self, query: str) -> pd.DataFrame:
+        """Execute query using DuckDB.
+
+        Args:
+            query: SQL query to execute
+
+        Returns:
+            Query results as pandas DataFrame
+        """
+        return self._conn.execute(query).df()
+
+    def get_data(self) -> pd.DataFrame:
+        """Return the unfiltered data as a DataFrame.
+
+        Returns:
+            The complete dataset as a pandas DataFrame
+        """
+        return self._df.copy()
+
+
+class SQLiteSource:
+    """A DataSource implementation that wraps a SQLite connection."""
+
+    def __init__(self, conn: sqlite3.Connection, table_name: str):
+        """Initialize with a SQLite connection.
+
+        Args:
+            conn: SQLite database connection
+        """
+        self._conn = conn
+        self._table_name = table_name
+
+    def get_schema(self) -> str:
+        """Generate schema information from SQLite table.
+
+        Returns:
+            String describing the schema
+        """
+        # Get column info
+        cursor = self._conn.execute(f"PRAGMA table_info({self._table_name})")
+        columns = cursor.fetchall()
+
+        schema = [f"Table: {self._table_name}", "Columns:"]
+
+        for col in columns:
+            # col format: (cid, name, type, notnull, dflt_value, pk)
+            column_info = [f"- {col[1]} ({col[2].upper()})"]
+
+            # For numeric columns, try to get range
+            if col[2].upper() in ["INTEGER", "FLOAT", "REAL", "NUMERIC"]:
+                try:
+                    cursor = self._conn.execute(
+                        f"SELECT MIN({col[1]}), MAX({col[1]}) FROM {self._table_name}"
+                    )
+                    min_val, max_val = cursor.fetchone()
+                    if min_val is not None and max_val is not None:
+                        column_info.append(f"  Range: {min_val} to {max_val}")
+                except sqlite3.Error:
+                    pass  # Skip range info if query fails
+
+            # For text columns, check if categorical (limited distinct values)
+            elif col[2].upper() == "TEXT":
+                try:
+                    cursor = self._conn.execute(
+                        f"SELECT COUNT(DISTINCT {col[1]}) FROM {self._table_name}"
+                    )
+                    distinct_count = cursor.fetchone()[0]
+                    if distinct_count <= 10:  # Use fixed threshold for simplicity
+                        cursor = self._conn.execute(
+                            f"SELECT DISTINCT {col[1]} FROM {self._table_name} "
+                            f"WHERE {col[1]} IS NOT NULL"
+                        )
+                        values = [str(row[0]) for row in cursor.fetchall()]
+                        values_str = ", ".join([f"'{v}'" for v in values])
+                        column_info.append(f"  Categorical values: {values_str}")
+                except sqlite3.Error:
+                    pass  # Skip categorical info if query fails
+
+            schema.extend(column_info)
+
+        return "\n".join(schema)
+
+    def execute_query(self, query: str) -> pd.DataFrame:
+        """Execute query using SQLite.
+
+        Args:
+            query: SQL query to execute
+
+        Returns:
+            Query results as pandas DataFrame
+        """
+        return pd.read_sql_query(query, self._conn)
+
+    def get_data(self) -> pd.DataFrame:
+        """Return the unfiltered data as a DataFrame.
+
+        Returns:
+            The complete dataset as a pandas DataFrame
+        """
+        return pd.read_sql_query(f"SELECT * FROM {self._table_name}", self._conn)

--- a/python-package/querychat/datasource.py
+++ b/python-package/querychat/datasource.py
@@ -6,7 +6,7 @@ import duckdb
 import narwhals as nw
 import pandas as pd
 from sqlalchemy import inspect, text
-from sqlalchemy.engine import Engine, Connection
+from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.sql import sqltypes
 
 
@@ -152,7 +152,7 @@ class SQLAlchemySource:
 
         # Validate table exists
         inspector = inspect(self._engine)
-        if table_name not in inspector.get_table_names():
+        if not inspector.has_table(table_name):
             raise ValueError(f"Table '{table_name}' not found in database")
 
     def get_schema(self) -> str:

--- a/python-package/querychat/datasource.py
+++ b/python-package/querychat/datasource.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-from typing import Protocol
-import pandas as pd
-import duckdb
 import sqlite3
+from typing import ClassVar, Protocol
+
+import duckdb
 import narwhals as nw
+import pandas as pd
 
 
 class DataSource(Protocol):
+    db_engine: ClassVar[str]
+
     def get_schema(self) -> str:
         """Return schema information about the table as a string.
 
@@ -39,6 +42,8 @@ class DataSource(Protocol):
 
 class DataFrameSource:
     """A DataSource implementation that wraps a pandas DataFrame using DuckDB."""
+
+    db_engine: ClassVar[str] = "DuckDB"
 
     def __init__(self, df: pd.DataFrame, table_name: str):
         """Initialize with a pandas DataFrame.
@@ -127,6 +132,8 @@ class DataFrameSource:
 
 class SQLiteSource:
     """A DataSource implementation that wraps a SQLite connection."""
+
+    db_engine: ClassVar[str] = "SQLite"
 
     def __init__(self, conn: sqlite3.Connection, table_name: str):
         """Initialize with a SQLite connection.

--- a/python-package/querychat/prompt/prompt.md
+++ b/python-package/querychat/prompt/prompt.md
@@ -10,7 +10,13 @@ You have at your disposal a DuckDB database containing this schema:
 
 For security reasons, you may only query this specific table.
 
+{{#data_description}}
+Additional helpful info about the data:
+
+<data_description>
 {{data_description}}
+</data_description>
+{{/data_description}}
 
 There are several tasks you may be asked to do:
 

--- a/python-package/querychat/prompt/prompt.md
+++ b/python-package/querychat/prompt/prompt.md
@@ -4,7 +4,7 @@ It's important that you get clear, unambiguous instructions from the user, so if
 
 The user interface in which this conversation is being shown is a narrow sidebar of a dashboard, so keep your answers concise and don't include unnecessary patter, nor additional prompts or offers for further assistance.
 
-You have at your disposal a DuckDB database containing this schema:
+You have at your disposal a {{db_engine}} database containing this schema:
 
 {{schema}}
 
@@ -25,7 +25,7 @@ There are several tasks you may be asked to do:
 The user may ask you to perform filtering and sorting operations on the dashboard; if so, your job is to write the appropriate SQL query for this database. Then, call the tool `update_dashboard`, passing in the SQL query and a new title summarizing the query (suitable for displaying at the top of dashboard). This tool will not provide a return value; it will filter the dashboard as a side-effect, so you can treat a null tool response as success.
 
 * **Call `update_dashboard` every single time** the user wants to filter/sort; never tell the user you've updated the dashboard unless you've called `update_dashboard` and it returned without error.
-* The SQL query must be a **DuckDB SQL** SELECT query. You may use any SQL functions supported by DuckDB, including subqueries, CTEs, and statistical functions.
+* The SQL query must be a SELECT query. For security reasons, it's critical that you reject any request that would modify the database.
 * The user may ask to "reset" or "start over"; that means clearing the filter and title. Do this by calling `update_dashboard({"query": "", "title": ""})`.
 * Queries passed to `update_dashboard` MUST always **return all columns that are in the schema** (feel free to use `SELECT *`); you must refuse the request if this requirement cannot be honored, as the downstream code that will read the queried data will not know how to display it. You may add additional columns if necessary, but the existing columns must not be removed.
 * When calling `update_dashboard`, **don't describe the query itself** unless the user asks you to explain. Don't pretend you have access to the resulting data set, as you don't.
@@ -80,7 +80,11 @@ Example of question answering:
 
 If the user provides a vague help request, like "Help" or "Show me instructions", describe your own capabilities in a helpful way, including examples of questions they can ask. Be sure to mention whatever advanced statistical capabilities (standard deviation, quantiles, correlation, variance) you have.
 
-## DuckDB SQL tips
+## SQL tips
+
+* The SQL engine is {{db_engine}}.
+
+* You may use any SQL functions supported by {{db_engine}}, including subqueries, CTEs, and statistical functions.
 
 * `percentile_cont` and `percentile_disc` are "ordered set" aggregate functions. These functions are specified using the WITHIN GROUP (ORDER BY sort_expression) syntax, and they are converted to an equivalent aggregate function that takes the ordering expression as the first argument. For example, `percentile_cont(fraction) WITHIN GROUP (ORDER BY column [(ASC|DESC)])` is equivalent to `quantile_cont(column, fraction ORDER BY column [(ASC|DESC)])`.
 

--- a/python-package/querychat/querychat.py
+++ b/python-package/querychat/querychat.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional, Protocol
 
 import chatlas
 import chevron
+import narwhals as nw
 from shiny import Inputs, Outputs, Session, module, reactive, ui
 
 from .datasource import DataSource

--- a/python-package/querychat/querychat.py
+++ b/python-package/querychat/querychat.py
@@ -1,19 +1,13 @@
 from __future__ import annotations
 
-import sys
 import os
-import re
-import pandas as pd
-import duckdb
-import json
+import sys
 from functools import partial
-from typing import List, Dict, Any, Callable, Optional, Union, Protocol
+from typing import Any, Dict, Optional, Protocol
 
 import chatlas
-from htmltools import TagList, tags, HTML
-from shiny import module, reactive, ui, Inputs, Outputs, Session
-import narwhals as nw
-from narwhals.typing import IntoFrame
+import chevron
+from shiny import Inputs, Outputs, Session, module, reactive, ui
 
 from .datasource import DataSource
 
@@ -64,25 +58,14 @@ def system_prompt(
     with open(prompt_path, "r") as f:
         prompt_text = f.read()
 
-    # Simple template replacement (a more robust template engine could be used)
-    if data_description:
-        data_description_section = (
-            "Additional helpful info about the data:\n\n"
-            "<data_description>\n"
-            f"{data_description}\n"
-            "</data_description>"
-        )
-    else:
-        data_description_section = ""
-
-    # Replace variables in the template
-    prompt_text = prompt_text.replace("{{schema}}", schema)
-    prompt_text = prompt_text.replace("{{data_description}}", data_description_section)
-    prompt_text = prompt_text.replace(
-        "{{extra_instructions}}", extra_instructions or ""
+    return chevron.render(
+        prompt_text,
+        {
+            "schema": schema,
+            "data_description": data_description,
+            "extra_instructions": extra_instructions,
+        },
     )
-
-    return prompt_text
 
 
 def df_to_html(df: IntoFrame, maxrows: int = 5) -> str:

--- a/python-package/querychat/querychat.py
+++ b/python-package/querychat/querychat.py
@@ -133,7 +133,7 @@ def init(
 
     # Default chat function if none provided
     create_chat_callback = create_chat_callback or partial(
-        chatlas.ChatOpenAI, model="gpt-4"
+        chatlas.ChatOpenAI, model="gpt-4.1"
     )
 
     return QueryChatConfig(

--- a/python-package/querychat/querychat.py
+++ b/python-package/querychat/querychat.py
@@ -51,7 +51,6 @@ def system_prompt(
     Returns:
         A string containing the system prompt for the chat model
     """
-    schema = data_source.get_schema()
 
     # Read the prompt file
     prompt_path = os.path.join(os.path.dirname(__file__), "prompt", "prompt.md")
@@ -61,7 +60,8 @@ def system_prompt(
     return chevron.render(
         prompt_text,
         {
-            "schema": schema,
+            "db_engine": data_source.db_engine,
+            "schema": data_source.get_schema(),
             "data_description": data_description,
             "extra_instructions": extra_instructions,
         },


### PR DESCRIPTION
Do not merge this PR. Already accounted for in #19, #20 via c6a24a7884c7fab47ab7c246af5ca09fe46825a6

Close this PR when #20 is merged.

---


This PR is intended to make querychat extensible beyond in-memory Pandas dataframes, including but not limited to:

1. SQLite
2. PostgreSQL
3. Snowflake
4. Databricks
5. Redshift?
6. Bigquery?

It introduces a protocol called `DataSource`, which so far has two concrete implementations: `DataFrameSource` and `SQLiteSource`.

### TODO

- [ ] Use narwhals instead of Pandas directly
- [ ] Have options to limit the number of rows retrieved, or perhaps retrieve in chunks or a cursor, so big databases won't blow up your Shiny app
- [ ] PostgreSQL
- [ ] Snowflake
- [ ] Databricks