### PR TITLE
docs(py): update Python README.md for package installation

### DIFF
--- a/pkg-py/README.md
+++ b/pkg-py/README.md
@@ -13,7 +13,7 @@ querychat is a drop-in component for Shiny that allows users to query a data fra
 ## Installation
 
 ```bash
-pip install "querychat @ git+https://github.com/posit-dev/querychat#subdirectory=pkg-py"
+pip install "querychat @ git+https://github.com/posit-dev/querychat"
 ```
 
 ## How to use


### PR DESCRIPTION
Currently when installing with the subdirectory parameter, pip will return the following error:

```
ERROR: querychat@ git+https://github.com/posit-dev/querychat#subdirectory=pkg-py from git+https://github.com/posit-dev/querychat#subdirectory=pkg-py does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.
```

Looks like this is due to missing 'pyproject.toml' file, which is currently placed under the root directory. This change redirect the git repo to not use subdirectory, so that pip can discover and install the package correctly.