### PR TITLE
feat(r): Plotting capability

### DIFF
--- a/pkg-r/DESCRIPTION
+++ b/pkg-r/DESCRIPTION
@@ -16,9 +16,11 @@ Depends:
     R (>= 4.1.0)
 Imports:
     bslib,
+    callr,
     DBI,
     duckdb,
     ellmer,
+    ggplot2,
     glue,
     htmltools,
     jsonlite,

--- a/pkg-r/inst/prompt/prompt.md
+++ b/pkg-r/inst/prompt/prompt.md
@@ -94,4 +94,32 @@ If you find yourself offering example questions to the user as part of your resp
 
 * `percentile_cont` and `percentile_disc` are "ordered set" aggregate functions. These functions are specified using the WITHIN GROUP (ORDER BY sort_expression) syntax, and they are converted to an equivalent aggregate function that takes the ordering expression as the first argument. For example, `percentile_cont(fraction) WITHIN GROUP (ORDER BY column [(ASC|DESC)])` is equivalent to `quantile_cont(column, fraction ORDER BY column [(ASC|DESC)])`.
 
+## Task: Plotting with ggplot2
+
+You can create and update plots in the dashboard using the `update_plot` tool. This tool takes a string of R code that generates a ggplot2 plot using the data frame `df` (which contains the currently filtered data). The code you provide will be evaluated and the resulting plot will be displayed in the dashboard.
+
+* Always use valid R code that creates a ggplot2 plot and assigns it as the last expression (no assignment needed, just return the plot object).
+* The data frame available for plotting is named `df`.
+* Do not attempt to retrieve or manipulate data outside of `df`.
+* Only use plotting code that is safe and reproducible.
+
+## Plotting guardrails
+
+When generating R code for plotting, you must never use or reference any of the following functions or statements: `system`, `file`, `unlink`, `assign`, `library`, `require`, or any function that accesses the file system, environment, or external resources. Only use functions from `ggplot2` and the provided data frame `df`. Any attempt to use forbidden functions will result in an error and your code will not be executed.
+
+Example of plotting:
+
+> [User]  
+> Show me a scatterplot of x vs y.  
+> [/User]  
+> [ToolCall]  
+> update_plot({ggplot_code: "ggplot2::ggplot(df, ggplot2::aes(x = x, y = y)) + ggplot2::geom_point()"})  
+> [/ToolCall]  
+> [ToolResponse]  
+> null  
+> [/ToolResponse]  
+> [Assistant]  
+> Here is a scatterplot of x vs y.  
+> [/Assistant]
+
 {{extra_instructions}}


### PR DESCRIPTION
This might be out of scope for this project, so feel free to close this if so. 

I am aware of some commercial solutions that provides plotting within their data chat experiences (datachat, snowflake intelligence etc.), so I thought this could be a nice feature to add. 

I added a 
- ui component to render ggplot within the chat, 
- a function to evaluate ggplot2 code generated by LLM
- registered a new tool called `update_plot`. 
- utilized callr to run the plotting as a way to increase security of running arbitrary code and added guardrails to the prompt. 