### PR TITLE
Classify R Date class variables as duckdb DATE column types in schema

### DIFF
--- a/pkg-r/R/prompt.R
+++ b/pkg-r/R/prompt.R
@@ -123,7 +123,7 @@ df_to_schema <- function(
         categories_str <- paste0("'", categories, "'", collapse = ", ")
         info <- c(info, paste0("  Categorical values: ", categories_str))
       }
-    } else if (sql_type %in% c("INTEGER", "FLOAT", "DATETIME")) {
+    } else if (sql_type %in% c("INTEGER", "FLOAT", "DATE", "DATETIME")) {
       rng <- range(df[[column]], na.rm = TRUE)
       if (all(is.na(rng))) {
         info <- c(info, "  Range: NULL to NULL")

--- a/pkg-r/R/prompt.R
+++ b/pkg-r/R/prompt.R
@@ -105,8 +105,10 @@ df_to_schema <- function(
       "FLOAT"
     } else if (is.logical(df[[column]])) {
       "BOOLEAN"
+    } else if (inherits(df[[column]], "Date")) {
+      "DATE"
     } else if (inherits(df[[column]], "POSIXt")) {
-      "DATETIME"
+      "TIMESTAMP"
     } else {
       "TEXT"
     }

--- a/pkg-r/R/querychat.R
+++ b/pkg-r/R/querychat.R
@@ -83,7 +83,7 @@ querychat_init <- function(
     }
   }
   if (!is.null(greeting)) {
-    greeting <- paste(collapse = "\n", greeting)
+    greeting <- read_path_or_string(greeting)
   } else {
     rlang::warn(c(
       "No greeting provided; the LLM will be invoked at the start of the conversation to generate one.",

--- a/pkg-r/R/querychat.R
+++ b/pkg-r/R/querychat.R
@@ -8,7 +8,8 @@
 #'   that will appear in SQL queries. Ensure that it begins with a letter, and
 #'   contains only letters, numbers, and underscores. By default, querychat will
 #'   try to infer a table name using the name of the `df` argument.
-#' @param greeting A string in Markdown format, containing the initial message
+#' @param greeting Optional string or existing file path. The contents
+#'   should be in plain text or Markdown format, containing the initial message
 #'   to display to the user upon first loading the chatbot. If not provided, the
 #'   LLM will be invoked at the start of the conversation to generate one.
 #' @param ... Additional arguments passed to the `querychat_system_prompt()`
@@ -83,7 +84,7 @@ querychat_init <- function(
     }
   }
   if (!is.null(greeting)) {
-    greeting <- read_path_or_string(greeting)
+    greeting <- read_path_or_string(greeting, "greeting")
   } else {
     rlang::warn(c(
       "No greeting provided; the LLM will be invoked at the start of the conversation to generate one.",

--- a/pkg-r/README.md
+++ b/pkg-r/README.md
@@ -82,7 +82,7 @@ Currently, querychat uses DuckDB for its SQL engine. It's extremely fast and has
 
 ### Provide a greeting (recommended)
 
-When the querychat UI first appears, you will usually want it to greet the user with some basic instructions. By default, these instructions are auto-generated every time a user arrives; this is slow, wasteful, and unpredictable. Instead, you should create a file called `greeting.md`, and when calling `querychat_init`, pass `greeting = readLines("greeting.md")`.
+When the querychat UI first appears, you will usually want it to greet the user with some basic instructions. By default, these instructions are auto-generated every time a user arrives; this is slow, wasteful, and unpredictable. Instead, you should create a file called `greeting.md`, and when calling `querychat_init`, pass `greeting = "greeting.md"`.
 
 You can provide suggestions to the user by using the `<span class="suggestion"> </span>` tag.
 
@@ -160,7 +160,7 @@ which you can then pass via:
 ```r
 querychat_config <- querychat_init(
   mtcars,
-  data_description = readLines("data_description.md")
+  data_description = "data_description.md"
 )
 ```
 
@@ -178,7 +178,7 @@ querychat_config <- querychat_init(mtcars, extra_instructions = c(
 ))
 ```
 
-You can also put these instructions in a separate file and use `readLines()` to load them, as we did for `data_description` above.
+You can also put these instructions in a separate file and pass the file path to load them, as we did for `data_description` above.
 
 **Warning:** It is not 100% guaranteed that the LLM will always—or in many cases, ever—obey your instructions, and it can be difficult to predict which instructions will be a problem. So be sure to test extensively each time you change your instructions, and especially, if you change the model you use.
 

--- a/pkg-r/man/querychat_init.Rd
+++ b/pkg-r/man/querychat_init.Rd
@@ -31,7 +31,8 @@ that will appear in SQL queries. Ensure that it begins with a letter, and
 contains only letters, numbers, and underscores. By default, querychat will
 try to infer a table name using the name of the \code{df} argument.}
 
-\item{greeting}{A string in Markdown format, containing the initial message
+\item{greeting}{Optional string or existing file path. The contents
+should be in plain text or Markdown format, containing the initial message
 to display to the user upon first loading the chatbot. If not provided, the
 LLM will be invoked at the start of the conversation to generate one.}
 


### PR DESCRIPTION
Hey, thanks for this great pkg.

I noticed the `df_to_schema` function was classifying R Date classes as TEXT columns in the schema passed to the LLM, despite these variables being converted to the duckdb DATE column type in the database. 

This was causing SQL errors when asking the LLM to filter on date columns, so I've added the appropriate check for this in `df_to_schema` and included ranges for this column type in the output. 

I also noticed some incoherence in the readme instructions for including a `data_description` and `extra_instructions`. It suggests to pass the contents of a markdown file via `data_description = readLines("data_description.md")` but this actually causes an error in `read_path_or_string` when there is more than 1 line in the .md file:

```r
> shiny::runApp()
Error in `if (file.exists(x)) ...`:
! the condition has length > 1
``` 

So I've updated the readme to show that only the file path needs to be passed.

I also found it inconsistent that the greeting argument is never passed to `read_path_or_string` and so does need to be passed to `querychat_init` as `greeting = readLines("greeting.md")`. I thought it would be a better UX if `greeting`, `data_description`, and `extra_instructions` could all be passed in the same manner, so I've updated the code and docs to make this change for the `greeting` argument.

Thanks!