### PR TITLE
fix(update_dashboard): Return a confirmation message on successful update

### DIFF
--- a/pkg-py/src/querychat/querychat.py
+++ b/pkg-py/src/querychat/querychat.py
@@ -488,6 +488,8 @@ def mod_server(  # noqa: D417
         if title is not None:
             current_title.set(title)
 
+        return "Dashboard updated. Use `query` tool to review results, if needed."
+
     # Function to perform a SQL query and return results as JSON
     async def query(query: str):
         """

--- a/pkg-r/R/querychat.R
+++ b/pkg-r/R/querychat.R
@@ -198,6 +198,8 @@ querychat_server <- function(id, querychat_config) {
       if (!is.null(title)) {
         current_title(title)
       }
+
+      "Dashboard updated. Use `query` tool to review results, if needed."
     }
 
     # Perform a SQL query on the data, and return the results as JSON.
@@ -261,7 +263,7 @@ querychat_server <- function(id, querychat_config) {
       # Add user message to the chat history
       shinychat::chat_append(
         "chat",
-        chat$stream_async(input$chat_user_input)
+        chat$stream_async(input$chat_user_input, stream = "content")
       )
     })
 

--- a/pkg-r/R/querychat.R
+++ b/pkg-r/R/querychat.R
@@ -263,7 +263,7 @@ querychat_server <- function(id, querychat_config) {
       # Add user message to the chat history
       shinychat::chat_append(
         "chat",
-        chat$stream_async(input$chat_user_input, stream = "content")
+        chat$stream_async(input$chat_user_input)
       )
     })
 


### PR DESCRIPTION
Fixes #56

Prior to this PR, `update_dashboard()` tool doesn't return a value -- or in the R case it returns either `TRUE` or `FALSE` depending on whether the `title` is updated. 

This appears to confuse models, especially local models. This PR updates the tool return value to tell the model the dashboard was updated and to instruct it to use the query tool if needed to see the results.