### PR TITLE
fix(pkg-py): simplify DataSource inheritance/interface

### DIFF
--- a/pkg-py/src/querychat/datasource.py
+++ b/pkg-py/src/querychat/datasource.py
@@ -33,7 +33,7 @@ class DataSource(ABC):
         ...
 
     @abstractmethod
-    def get_schema(self, *, categorical_threshold) -> str:
+    def get_schema(self, *, categorical_threshold: int) -> str:
         """
         Return schema information about the table as a string.
 


### PR DESCRIPTION
The current `DataSource`/`DataSourceBase` setup is confusing -- one is for typing and the other for implementing. Also, you get no typing errors when implementing about missing methods.

I'm pretty sure what we want here is a single `ABC`, which avoids these two problems