### PR TITLE
fix(pkg-py): Standardize `categorical_threshold` default to 20

### DIFF
--- a/pkg-py/src/querychat/_deprecated.py
+++ b/pkg-py/src/querychat/_deprecated.py
@@ -77,7 +77,7 @@ def system_prompt(
     *,
     data_description: Optional[str | Path] = None,
     extra_instructions: Optional[str | Path] = None,
-    categorical_threshold: int = 10,
+    categorical_threshold: int = 20,
     prompt_template: Optional[str | Path] = None,
 ) -> str:
     """

--- a/pkg-py/src/querychat/_querychat.py
+++ b/pkg-py/src/querychat/_querychat.py
@@ -34,7 +34,7 @@ class QueryChatBase:
         greeting: Optional[str | Path] = None,
         client: Optional[str | chatlas.Chat] = None,
         data_description: Optional[str | Path] = None,
-        categorical_threshold: int = 10,
+        categorical_threshold: int = 20,
         extra_instructions: Optional[str | Path] = None,
         prompt_template: Optional[str | Path] = None,
     ):
@@ -532,7 +532,7 @@ class QueryChatExpress(QueryChatBase):
         greeting: Optional[str | Path] = None,
         client: Optional[str | chatlas.Chat] = None,
         data_description: Optional[str | Path] = None,
-        categorical_threshold: int = 10,
+        categorical_threshold: int = 20,
         extra_instructions: Optional[str | Path] = None,
         prompt_template: Optional[str | Path] = None,
         enable_bookmarking: Literal["auto", True, False] = "auto",
@@ -697,7 +697,7 @@ def get_system_prompt(
     *,
     data_description: Optional[str | Path] = None,
     extra_instructions: Optional[str | Path] = None,
-    categorical_threshold: int = 10,
+    categorical_threshold: int = 20,
     prompt_template: Optional[str | Path] = None,
 ) -> str:
     # Read the prompt file


### PR DESCRIPTION
Updates the Python package to use categorical_threshold=20 as the default value, matching the R package default. This resolves the inconsistency between the two implementations.

Fixes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)