### PR TITLE
fix(pkg-r): `DBI::SQL()` errors given `NULL`

### DIFF
--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -32,7 +32,7 @@ mod_server <- function(
     current_query <- shiny::reactiveVal(NULL, label = "current_query")
     has_greeted <- shiny::reactiveVal(FALSE, label = "has_greeted")
     filtered_df <- shiny::reactive(label = "filtered_df", {
-      data_source$execute_query(query = DBI::SQL(current_query()))
+      data_source$execute_query(query = current_query())
     })
 
     append_output <- function(...) {


### PR DESCRIPTION
Introduced by #149. I'm pretty sure the `DBI::SQL()` isn't needed in the first place, so we can just drop it.

Here's a reprex:

```r
library(shiny)
library(bslib)
library(querychat)
library(palmerpenguins)

qc <- QueryChat$new(penguins)

ui <- page_sidebar(
  sidebar = qc$sidebar(),
  dataTableOutput("table")
)

server <- function(input, output, session) {
  qc_vals <- qc$server()
  
  output$table <- renderDataTable({
    qc_vals$df()
  })
}

shinyApp(ui, server)
```

```
Warning: Error in initialize: cannot use object of class “NULL” in new():  class “SQL” does not extend that class
```