### PR TITLE
fix(pkg-r): Directly expose `id` rather than ask for `ns()` function

### DIFF
--- a/pkg-r/R/QueryChat.R
+++ b/pkg-r/R/QueryChat.R
@@ -474,8 +474,10 @@ QueryChat <- R6::R6Class(
     #' @param width Width of the sidebar in pixels. Default is 400.
     #' @param height Height of the sidebar. Default is "100%".
     #' @param fillable Whether the sidebar should be fillable. Default is `TRUE`.
-    #' @param ns A Shiny namespacing (i.e., [shiny::NS()]) function.
-    #' Only needed when calling this method within a module UI function.
+    #' @param id Optional ID for the QueryChat instance. If not provided,
+    #'   will use the ID provided at initialization. If using `$sidebar()` in
+    #'   a Shiny module, you'll need to provide `id = ns("your_id")` where `ns`
+    #'   is the namespacing function from [shiny::NS()].
     #'
     #' @return A [bslib::sidebar()] UI component.
     #'
@@ -493,7 +495,7 @@ QueryChat <- R6::R6Class(
       width = 400,
       height = "100%",
       fillable = TRUE,
-      ns = NULL
+      id = NULL
     ) {
       bslib::sidebar(
         width = width,
@@ -501,7 +503,7 @@ QueryChat <- R6::R6Class(
         fillable = fillable,
         class = "querychat-sidebar",
         ...,
-        self$ui(ns = ns)
+        self$ui(id = id)
       )
     },
 
@@ -513,10 +515,9 @@ QueryChat <- R6::R6Class(
     #'
     #' @param ... Additional arguments passed to [shinychat::chat_ui()].
     #' @param id Optional ID for the QueryChat instance. If not provided,
-    #'   will use the ID provided at initialization. This argument is included
-    #'   for use within Shiny modules; in which case you'll need to provide
-    #'   `id = ns("your_id")` where `ns` is the namespacing function from
-    #'   [shiny::NS()].
+    #'   will use the ID provided at initialization. If using `$ui()` in a Shiny
+    #'   module, you'll need to provide `id = ns("your_id")` where `ns` is the
+    #'   namespacing function from [shiny::NS()].
     #'
     #' @return A UI component containing the chat interface.
     #'
@@ -558,7 +559,9 @@ QueryChat <- R6::R6Class(
     #' @param ... Ignored.
     #' @param id Optional module ID for the QueryChat instance. If not provided,
     #'   will use the ID provided at initialization. When used in Shiny modules,
-    #'   this `id` should match the `id` used in the corresponding UI function.
+    #'   this `id` should match the `id` used in the corresponding UI function
+    #'   (i.e., `qc$ui(id = ns("your_id"))` pairs with `qc$server(id =
+    #'   "your_id")`).
     #' @param session The Shiny session object.
     #'
     #' @return A list containing session-specific reactive values and the chat

--- a/pkg-r/man/QueryChat.Rd
+++ b/pkg-r/man/QueryChat.Rd
@@ -489,7 +489,7 @@ interface, suitable for use with \code{\link[bslib:page_sidebar]{bslib::page_sid
   width = 400,
   height = "100\%",
   fillable = TRUE,
-  ns = NULL
+  id = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -504,8 +504,10 @@ interface, suitable for use with \code{\link[bslib:page_sidebar]{bslib::page_sid
 
 \item{\code{fillable}}{Whether the sidebar should be fillable. Default is \code{TRUE}.}
 
-\item{\code{ns}}{A Shiny namespacing (i.e., \code{\link[shiny:NS]{shiny::NS()}}) function.
-Only needed when calling this method within a module UI function.}
+\item{\code{id}}{Optional ID for the QueryChat instance. If not provided,
+will use the ID provided at initialization. If using \verb{$sidebar()} in
+a Shiny module, you'll need to provide \code{id = ns("your_id")} where \code{ns}
+is the namespacing function from \code{\link[shiny:NS]{shiny::NS()}}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -546,10 +548,9 @@ This method generates the chat UI component. Typically you'll use
 \item{\code{...}}{Additional arguments passed to \code{\link[shinychat:chat_ui]{shinychat::chat_ui()}}.}
 
 \item{\code{id}}{Optional ID for the QueryChat instance. If not provided,
-will use the ID provided at initialization. This argument is included
-for use within Shiny modules; in which case you'll need to provide
-\code{id = ns("your_id")} where \code{ns} is the namespacing function from
-\code{\link[shiny:NS]{shiny::NS()}}.}
+will use the ID provided at initialization. If using \verb{$ui()} in a Shiny
+module, you'll need to provide \code{id = ns("your_id")} where \code{ns} is the
+namespacing function from \code{\link[shiny:NS]{shiny::NS()}}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -603,7 +604,8 @@ parameter of \code{shiny::shinyApp()}.}
 
 \item{\code{id}}{Optional module ID for the QueryChat instance. If not provided,
 will use the ID provided at initialization. When used in Shiny modules,
-this \code{id} should match the \code{id} used in the corresponding UI function.}
+this \code{id} should match the \code{id} used in the corresponding UI function
+(i.e., \code{qc$ui(id = ns("your_id"))} pairs with \code{qc$server(id = "your_id")}).}
 
 \item{\code{session}}{The Shiny session object.}
 }


### PR DESCRIPTION
This stacks on #172 and is an alternate approach that exposes `id`.

The `ns` argument in #172 is convenient, but it's also not a standard a pattern that we use in Shiny modules. In general, it's normal to expect that you'll need to wrap any `id` for any component in `ns()`, e.g. `id = ns("component")`, in a Shiny module, including when you're nesting Shiny modules.

Passing in `ns` is an interesting idea, but it's not the standard established pattern and I'm not sure it's entirely worth it because it doesn't entire enable another class of use cases.

Allowing users to pass in `id`, on the other hand, **is** idiomatic and expected and gives users extra flexibility to call `$ui()` and `$server()` with alternate IDs, even in a non-module use case. That's entirely valid because we've decoupled the `$server()` return values from the parent QueryChat class.

## Example

Here's the example in #172 updated to use the new pattern.

```r
library(shiny)
library(bslib)
library(querychat)

qc <- QueryChat$new(mtcars, greeting = "Ask me about mtcars!")

module_ui <- function(id, qc) {
  ns <- NS(id)
  card(qc$ui(id = ns("qc-ui"))) #<< this is normal Shiny module stuff
}

module_server <- function(id, qc) {
  moduleServer(id, function(input, output, session) {
    qc$server(id = "qc-ui") #<< also expected in a Shiny module
  })
}

ui <- page_fluid(
  titlePanel("QueryChat Module Test"),
  module_ui("module1", qc)
)

server <- function(input, output, session) {
  module_server("module1", qc)
}

shinyApp(ui, server)
```

So while the new R6 class saves you from needing to pass IDs around when you're using `qc$ui()` and `qc$server()` in a normal Shiny app (and you only have one), if you're in Shiny modules or if you have more than one chat from the same `qc` source object, you'll be able to connect the `id`s by passing them explicitly.