### PR TITLE
chore(pkg-py): adopt hatch-vcs and add py.typed marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
+__version.py
 animation.screenflow/
 README_files/
 README.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "querychat"
-version = "0.5.1"
+dynamic = ["version"]
 description = "Chat with your data using natural language"
 readme = "pkg-py/README.md"
 requires-python = ">=3.10"
@@ -64,6 +64,16 @@ packages = ["pkg-py/src/querychat"]
 [tool.hatch.build.targets.sdist]
 include = ["pkg-py/src/querychat", "pkg-py/LICENSE", "pkg-py/README.md"]
 
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^py/(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$"
+
+[tool.hatch.version.raw-options]
+git_describe_command = "git describe --dirty --tags --long --match 'py/v*'"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "pkg-py/src/querychat/__version.py"
+
 [dependency-groups]
 dev = ["ruff>=0.6.5", "pyright>=1.1.401", "tox-uv>=1.11.4", "pytest>=8.4.0", "polars>=1.0.0", "pyarrow>=14.0.0", "ibis-framework[duckdb]>=9.0.0"]
 docs = ["quartodoc>=0.11.1", "griffe<2", "nbformat", "nbclient", "ipykernel"]
@@ -86,6 +96,7 @@ test = [
 [tool.ruff]
 src = ["pkg-py/src/querychat"]
 exclude = [
+    "__version.py",
     ".bzr",
     ".direnv",
     ".eggs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["pkg-py/src/querychat"]
+include = ["py.typed"]
 
 [tool.hatch.build.targets.sdist]
 include = ["pkg-py/src/querychat", "pkg-py/LICENSE", "pkg-py/README.md"]


### PR DESCRIPTION
## Summary
- Replace static `version = "0.5.1"` in `pyproject.toml` with dynamic versioning via `hatch-vcs`
- Auto-generates `__version.py` from `py/v*` git tags, matching the convention used in `shinychat`
- Add `__version.py` to `.gitignore` and ruff exclude list
- Add `py.typed` marker (PEP 561) so type checkers recognize inline annotations

## Test plan
- [x] `uv sync` resolves version correctly from git tags
- [x] `from querychat.__version import __version__` works at runtime
- [x] All 270 tests pass
- [ ] Verify version resolves correctly in CI build

🤖 Generated with [Claude Code](https://claude.com/claude-code)