### PR TITLE
feat(docs): add Plausible analytics to Python and R doc sites

### DIFF
--- a/pkg-py/docs/_quarto.yml
+++ b/pkg-py/docs/_quarto.yml
@@ -65,6 +65,8 @@ website:
 
 format:
   html:
+    include-in-header:
+      - "include-in-header.html"
     theme:
       - styles.scss
     toc: true

--- a/pkg-py/docs/include-in-header.html
+++ b/pkg-py/docs/include-in-header.html
@@ -1,0 +1,6 @@
+<!-- Privacy-friendly analytics by Plausible -->
+<script async src="https://plausible.io/js/pa-wgo-tEXQwSOuN51WDI0ry.js"></script>
+<script>
+  window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+  plausible.init()
+</script>

--- a/pkg-r/pkgdown/_pkgdown.yml
+++ b/pkg-r/pkgdown/_pkgdown.yml
@@ -26,6 +26,14 @@ template:
   light-switch: true
   theme: github-light
   theme-dark: github-dark
+  includes:
+    in_header: |
+      <!-- Privacy-friendly analytics by Plausible -->
+      <script async src="https://plausible.io/js/pa-wgo-tEXQwSOuN51WDI0ry.js"></script>
+      <script>
+        window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+        plausible.init()
+      </script>
   bslib:
     brand: pkgdown/_brand.yml
 


### PR DESCRIPTION
## Summary

- Adds Plausible analytics script to the Python Quarto docs via `include-in-header.html` and `_quarto.yml`
- Adds Plausible analytics script to the R pkgdown docs via inline `includes: in_header` in `_pkgdown.yml`
- Follows the same patterns used by chatlas (Quarto) and ellmer (pkgdown)