### PR TITLE
fix(tests): update Gradio Playwright selector for virtual scrolling

### DIFF
--- a/pkg-py/tests/playwright/test_05_gradio_apps.py
+++ b/pkg-py/tests/playwright/test_05_gradio_apps.py
@@ -174,8 +174,10 @@ class Test07GradioCustom:
         page.wait_for_selector("gradio-app", timeout=30000)
         # Wait for load callback to populate SQL and data
         page.wait_for_selector(".cm-content", timeout=30000)
-        # Wait for data table to be populated (indicates load callback completed)
-        page.wait_for_selector("table tbody tr", timeout=30000)
+        # Wait for data table to be populated (indicates load callback completed).
+        # Gradio 6.11+ uses virtual scrolling: actual data rows are .virtual-row
+        # divs, not table tbody tr elements (those are hidden sizing rows).
+        page.wait_for_selector(".virtual-row", timeout=30000)
         self.page = page
 
     # ==================== Initial Load Tests ====================


### PR DESCRIPTION
## Summary

- Gradio 6.11+ migrated `gr.Dataframe` to virtual scrolling, which made the `table tbody tr` selector in `Test07GradioCustom` wait forever on hidden sizing rows (`visibility: collapse`)
- Updated the selector to `.virtual-row`, which targets the actual visible data rows in the new virtual scrolling DOM structure
- Fixes all 10 `Test07GradioCustom` Playwright test failures

## Test plan

- [ ] `Test07GradioCustom` Playwright tests pass locally
- [ ] CI Playwright job passes (previously failing with 10 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)