### PR TITLE
fix(pkg-py): add minimum narwhals version constraint (>=2.2.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "shinychat>=0.2.8",
     "htmltools",
     "chatlas>=0.13.2",
-    "narwhals",
+    "narwhals>=2.2.0",
     "chevron",
     "sqlalchemy>=2.0.0", # Using 2.0+ for improved type hints and API
     "great-tables>=0.16.0",


### PR DESCRIPTION
## Summary
- `querychat` imports `IntoLazyFrameT` from `narwhals.stable.v1.typing`, which was introduced in narwhals 2.2.0
- Without a lower bound on the `narwhals` dependency, resolvers can pick older versions (e.g. 1.40.0) that don't export this type, causing `ImportError` at runtime
- Adds `narwhals>=2.2.0` to the project dependencies
