### PR TITLE
chore: confirm E2E failures reproduce on main

### DIFF
--- a/pkg-py/src/querychat/__init__.py
+++ b/pkg-py/src/querychat/__init__.py
@@ -1,4 +1,4 @@
-from ._deprecated import greeting, init, sidebar, system_prompt
+from ._deprecated import greeting, init, sidebar, system_prompt  # noqa: F401
 from ._deprecated import mod_server as server
 from ._deprecated import mod_ui as ui
 from ._shiny import QueryChat


### PR DESCRIPTION
## Summary
- No-op change to trigger the Playwright E2E workflow against main
- Confirms that Streamlit/Gradio `test_submit_query_via_enter` failures are pre-existing on main, not introduced by the deferred-client branch
- The error is `AttributeError: 'NoneType' object has no attribute 'output'` in chatlas's OpenAI provider

## Test plan
- [ ] Watch the E2E workflow run — expect the same Streamlit/Gradio submit test failures seen on the deferred-client branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)