### PR TITLE
refactor(pkg-r): remove dead else branch in mod_server

### DIFF
--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -62,21 +62,11 @@ mod_server <- function(
     }
 
     # Set up the chat object for this session
-    if (is_function(client)) {
-      # This is the `QueryChat$client` function, or generally a function that
-      # takes the update/reset callbacks and returns a realized QC chat client
-      chat <- client(
-        update_dashboard = update_dashboard,
-        reset_dashboard = reset_query
-      )
-    } else {
-      chat <- client$clone()
-      chat$register_tool(
-        tool_update_dashboard(data_source, update_fn = update_dashboard)
-      )
-      chat$register_tool(tool_query(data_source))
-      chat$register_tool(tool_reset_dashboard(reset_query))
-    }
+    check_function(client)
+    chat <- client(
+      update_dashboard = update_dashboard,
+      reset_dashboard = reset_query
+    )
 
     # Prepopulate the chat UI with a welcome message that appears to be from the
     # chat model (but is actually hard-coded). This is just for the user, not for


### PR DESCRIPTION
## Summary

Removes an unreachable `else` branch in `mod_server()` that was left behind after #207 refactored client creation.

**Before #207**, `mod_server()` accepted either a function (client factory) or a pre-built `Chat` object. The `else` branch handled the latter case by cloning the Chat and manually registering tools.

**After #207**, `QueryChat$server()` always wraps `private$create_session_client()` in a closure and passes that as `client` — so `mod_server()` always receives a function. The `else` branch became dead code.

This is a problem because the `else` branch:
- Hardcodes registering only `update`, `query`, and `reset` tools (ignoring the `tools` parameter)
- Would silently do the wrong thing if somehow reached

This PR replaces the `if`/`else` with `check_function(client)` + a direct call, matching the Python `mod_server` which raises `TypeError` for non-callable clients.

## Test plan

- [x] Existing test suite passes (622 tests, 0 failures)
- [x] Verified via `git log` that no code path passes a non-function `client` to `mod_server()` since #207