### PR TITLE
chore(pkg-py): prepare querychat for ggsql 0.3.0

### DIFF
--- a/pkg-py/src/querychat/_viz_tools.py
+++ b/pkg-py/src/querychat/_viz_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import copy
 import io
+import re
 from typing import TYPE_CHECKING, Any, TypedDict
 from uuid import uuid4
 
@@ -163,9 +164,9 @@ def visualize_impl(
                 )
 
             if not validated.valid():
-                errors = validated.errors()
-                if errors:
-                    raise ValueError(errors[0]["message"])
+                error_msg = safe_visual_validation_error(validated)
+                if error_msg is not None:
+                    raise ValueError(error_msg)
 
             spec = execute_ggsql(data_source, validated)
 
@@ -195,6 +196,44 @@ def visualize_impl(
             return ContentToolResult(value=markdown, error=Exception(error_msg))
 
     return visualize
+
+
+_VISUALISE_MESSAGE_ONLY_COLUMNS = "Mappings accept column names only"
+_VISUALISE_FUNCTION_CALL_RE = re.compile(r"\b[a-z_][a-z0-9_]*\s*\(", re.IGNORECASE)
+_VISUALISE_MAPPINGS_RE = re.compile(
+    r"^\s*VISUALISE\s+(.*?)(?=\b(?:DRAW|FROM|SCALE|PROJECT|FACET|PLACE|LABEL|THEME)\b|$)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def safe_visual_validation_error(validated: Any) -> str | None:
+    """Return an upstream validation error only when it is specific enough."""
+    errors = validated.errors()
+    if not errors:
+        return None
+
+    message = errors[0]["message"]
+    if _VISUALISE_MESSAGE_ONLY_COLUMNS not in message:
+        return message
+
+    if visualise_clause_looks_expression_driven(validated.visual()):
+        return message
+
+    return None
+
+
+def visualise_clause_looks_expression_driven(visual: str) -> bool:
+    """Heuristically detect SQL-expression-like mappings in VISUALISE."""
+    mappings = extract_visualise_mappings(visual)
+    return bool(_VISUALISE_FUNCTION_CALL_RE.search(mappings))
+
+
+def extract_visualise_mappings(visual: str) -> str:
+    """Return the mappings portion of a VISUALISE clause."""
+    match = _VISUALISE_MAPPINGS_RE.search(visual)
+    if match is None:
+        return visual
+    return match.group(1)
 
 
 PNG_WIDTH = 500

--- a/pkg-py/src/querychat/_viz_tools.py
+++ b/pkg-py/src/querychat/_viz_tools.py
@@ -163,7 +163,9 @@ def visualize_impl(
                 )
 
             if not validated.valid():
-                raise ValueError(validated.errors()[0]["message"])
+                raise ValueError(
+                    "\n".join(error["message"] for error in validated.errors())
+                )
 
             spec = execute_ggsql(data_source, validated)
 

--- a/pkg-py/src/querychat/_viz_tools.py
+++ b/pkg-py/src/querychat/_viz_tools.py
@@ -157,27 +157,15 @@ def visualize_impl(
         try:
             validated = validate(ggsql)
             if not validated.has_visual():
-                # When VISUALISE contains SQL expressions (e.g., CAST()),
-                # ggsql silently treats the entire query as plain SQL:
-                # valid()=True, has_visual()=False, no errors. This
-                # heuristic catches that case so we can guide the LLM.
-                # Remove when ggsql reports this as a parse error:
-                # https://github.com/posit-dev/ggsql/issues/256
-                has_keyword = (
-                    "VISUALISE" in ggsql.upper() or "VISUALIZE" in ggsql.upper()
-                )
-                if has_keyword:
-                    raise ValueError(
-                        "VISUALISE clause was not recognized. "
-                        "VISUALISE and MAPPING accept column names only — "
-                        "no SQL expressions, CAST(), or functions. "
-                        "Move all data transformations to the SELECT clause, "
-                        "then reference the resulting column by name in VISUALISE."
-                    )
                 raise ValueError(
                     "Query must include a VISUALISE clause. "
                     "Use querychat_query for queries without visualization."
                 )
+
+            if not validated.valid():
+                errors = validated.errors()
+                if errors:
+                    raise ValueError(errors[0]["message"])
 
             spec = execute_ggsql(data_source, validated)
 

--- a/pkg-py/src/querychat/_viz_tools.py
+++ b/pkg-py/src/querychat/_viz_tools.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import base64
 import copy
 import io
-import re
 from typing import TYPE_CHECKING, Any, TypedDict
 from uuid import uuid4
 
@@ -164,9 +163,7 @@ def visualize_impl(
                 )
 
             if not validated.valid():
-                error_msg = safe_visual_validation_error(validated)
-                if error_msg is not None:
-                    raise ValueError(error_msg)
+                raise ValueError(validated.errors()[0]["message"])
 
             spec = execute_ggsql(data_source, validated)
 
@@ -196,45 +193,6 @@ def visualize_impl(
             return ContentToolResult(value=markdown, error=Exception(error_msg))
 
     return visualize
-
-
-_VISUALISE_MESSAGE_ONLY_COLUMNS = "Mappings accept column names only"
-_VISUALISE_FUNCTION_CALL_RE = re.compile(r"\b[a-z_][a-z0-9_]*\s*\(", re.IGNORECASE)
-_VISUALISE_MAPPINGS_RE = re.compile(
-    r"^\s*VISUALISE\s+(.*?)(?=\b(?:DRAW|FROM|SCALE|PROJECT|FACET|PLACE|LABEL|THEME)\b|$)",
-    re.IGNORECASE | re.DOTALL,
-)
-
-
-def safe_visual_validation_error(validated: Any) -> str | None:
-    """Return an upstream validation error only when it is specific enough."""
-    errors = validated.errors()
-    if not errors:
-        return None
-
-    message = errors[0]["message"]
-    if _VISUALISE_MESSAGE_ONLY_COLUMNS not in message:
-        return message
-
-    if visualise_clause_looks_expression_driven(validated.visual()):
-        return message
-
-    return None
-
-
-def visualise_clause_looks_expression_driven(visual: str) -> bool:
-    """Heuristically detect SQL-expression-like mappings in VISUALISE."""
-    mappings = extract_visualise_mappings(visual)
-    return bool(_VISUALISE_FUNCTION_CALL_RE.search(mappings))
-
-
-def extract_visualise_mappings(visual: str) -> str:
-    """Return the mappings portion of a VISUALISE clause."""
-    match = _VISUALISE_MAPPINGS_RE.search(visual)
-    if match is None:
-        return visual
-    return match.group(1)
-
 
 PNG_WIDTH = 500
 PNG_HEIGHT = 300

--- a/pkg-py/src/querychat/prompts/ggsql-syntax.md
+++ b/pkg-py/src/querychat/prompts/ggsql-syntax.md
@@ -33,6 +33,11 @@ DRAW line
 -- Shorthand with FROM (auto-generates SELECT * FROM)
 VISUALISE FROM sales
 DRAW bar MAPPING region AS x, total AS y
+
+-- FROM can also come first
+FROM sales
+VISUALISE date AS x, revenue AS y
+DRAW line
 ```
 
 ### Mapping Styles
@@ -65,7 +70,7 @@ DRAW geom_type
 |----------|-------|
 | Basic | `point`, `line`, `path`, `bar`, `area`, `tile`, `polygon`, `ribbon` |
 | Statistical | `histogram`, `density`, `smooth`, `boxplot`, `violin` |
-| Annotation | `text`, `label`, `segment`, `arrow`, `rule`, `rect`, `errorbar` |
+| Annotation | `text`, `label`, `segment`, `arrow`, `rule`, `rect`, `range` |
 
 - `path` is like `line` but preserves data order instead of sorting by x.
 - `tile` draws rectangles for heatmaps or range indicators. Map `x`/`y` for center (defaults to width/height of 1), or use `xmin`/`xmax`/`ymin`/`ymax` for explicit bounds.
@@ -74,7 +79,8 @@ DRAW geom_type
 - `arrow` draws arrows between two points. Requires `x`, `y`, `xend`, `yend` aesthetics.
 - `rule` draws full-span reference lines. Map a value to `y` for a horizontal line or `x` for a vertical line. Optionally map `slope` to create diagonal reference lines: `y = a + slope * x` (when `y` is mapped) or `x = a + slope * y` (when `x` is mapped).
 - `rect` draws rectangles. Pick 2 per axis from center (`x`/`y`), min (`xmin`/`ymin`), max (`xmax`/`ymax`), `width`, `height`. Or just map center (defaults to width/height of 1).
-- `errorbar` displays interval marks. Requires `x`, `ymin`, `ymax`. Settings: `width` (hinge width in points, default 10; `null` to hide hinges).
+- `range` displays interval marks. Requires `x`, `ymin`, `ymax` for vertical intervals, or `y`, `xmin`, `xmax` for horizontal intervals. Use it for confidence intervals, lollipops, and candlestick-style ranges. Setting `width => null` hides the hinges.
+- `segment` draws arbitrary connections between two points and requires `x`, `y`, `xend`, and `yend`.
 - `line` and `path` support continuously varying `linewidth`, `stroke`, and `opacity` aesthetics within groups.
 
 **Aesthetics (MAPPING):**
@@ -446,7 +452,7 @@ DRAW text MAPPING n AS label SETTING offset => (0, -11), fill => 'white'
 ```sql
 SELECT ROUND(bill_dep) AS bill_dep, COUNT(*) AS n FROM penguins GROUP BY 1
 VISUALISE bill_dep AS x, n AS y
-DRAW segment MAPPING 0 AS yend
+DRAW range MAPPING 0 AS ymin, n AS ymax SETTING width => null
 DRAW point
 ```
 

--- a/pkg-py/src/querychat/prompts/prompt.md
+++ b/pkg-py/src/querychat/prompts/prompt.md
@@ -121,7 +121,7 @@ This simple response is sufficient, as the user can see the SQL query used.
 {{#has_tool_visualize}}
 ### Visualizing Data
 
-You can create visualizations using the `querychat_visualize` tool, which uses ggsql — a SQL extension for declarative data visualization. Write a ggsql query (SQL with a VISUALISE clause), and the tool executes the SQL, renders the VISUALISE clause as an Altair chart, and displays it inline in the chat.
+You can create visualizations using the `querychat_visualize` tool, which uses ggsql — a SQL extension for declarative data visualization. Write a ggsql query (SQL with a `VISUALISE` clause), and the tool executes the SQL, renders the `VISUALISE` clause as an Altair chart, and displays it inline in the chat.
 
 #### Visualization best practices
 

--- a/pkg-py/src/querychat/prompts/tool-visualize.md
+++ b/pkg-py/src/querychat/prompts/tool-visualize.md
@@ -6,9 +6,9 @@ Render a ggsql query (SQL with a VISUALISE clause) as an Altair chart displayed 
 
 **Key constraints:**
 
-- All data transformations must happen in the SELECT clause — VISUALISE and MAPPING accept column names only, not SQL expressions or functions
-- Do NOT include `LABEL title => ...` in the query — use the `title` parameter instead
-- If a visualization fails, read the error message carefully and retry with a corrected query. Common fixes: correcting column names, adding `SCALE DISCRETE` for integer categories, using single quotes for strings, moving SQL expressions out of VISUALISE into the SELECT clause.{{#has_tool_query}} If the error persists, fall back to `querychat_query` for a tabular answer.{{/has_tool_query}}
+- All data transformations must happen in the `SELECT` clause. `VISUALISE` and `MAPPING` accept column names only, not SQL expressions or functions.
+- Do NOT include `LABEL title => ...` in the query — use the `title` parameter instead.
+- If a visualization fails, read the error message carefully and retry with a corrected query. Common fixes: correcting column names, adding `SCALE DISCRETE` for integer categories, moving SQL expressions out of `VISUALISE` into the `SELECT` clause, and using `DRAW range` for interval-style marks instead of deprecated `errorbar`.{{#has_tool_query}} If the error persists, fall back to `querychat_query` for a tabular answer.{{/has_tool_query}}
 
 Parameters
 ----------

--- a/pkg-py/tests/test_ggsql.py
+++ b/pkg-py/tests/test_ggsql.py
@@ -50,6 +50,34 @@ class TestHasLayerLevelSource:
 class TestGgsqlValidate:
     """Tests for ggsql.validate() usage (split SQL and VISUALISE)."""
 
+    def test_accepts_from_before_visualise(self):
+        query = "FROM data VISUALISE x, y DRAW point"
+        validated = ggsql.validate(query)
+        assert validated.has_visual()
+        assert validated.sql() == "SELECT * FROM data"
+        assert validated.visual() == "VISUALISE x, y DRAW point"
+
+    def test_accepts_from_before_visualise_for_test_data(self):
+        query = "FROM test_data VISUALISE x, y DRAW point"
+        validated = ggsql.validate(query)
+        assert validated.has_visual()
+        assert validated.sql() == "SELECT * FROM test_data"
+        assert validated.visual() == "VISUALISE x, y DRAW point"
+
+    def test_reports_upstream_error_for_expression_in_visualise(self):
+        query = (
+            "SELECT CAST(x AS DOUBLE) AS x2 "
+            "FROM data "
+            "VISUALISE CAST(x2 AS DOUBLE) AS x "
+            "DRAW point"
+        )
+        validated = ggsql.validate(query)
+        assert not validated.valid()
+        assert any(
+            "Mappings accept column names only" in error["message"]
+            for error in validated.errors()
+        )
+
     def test_splits_query_with_visualise(self):
         query = "SELECT x, y FROM data VISUALISE x, y DRAW point"
         validated = ggsql.validate(query)

--- a/pkg-py/tests/test_ggsql.py
+++ b/pkg-py/tests/test_ggsql.py
@@ -53,6 +53,7 @@ class TestGgsqlValidate:
     def test_accepts_from_before_visualise(self):
         query = "FROM data VISUALISE x, y DRAW point"
         validated = ggsql.validate(query)
+        assert validated.valid()
         assert validated.has_visual()
         assert validated.sql() == "SELECT * FROM data"
         assert validated.visual() == "VISUALISE x, y DRAW point"
@@ -60,6 +61,7 @@ class TestGgsqlValidate:
     def test_accepts_from_before_visualise_for_test_data(self):
         query = "FROM test_data VISUALISE x, y DRAW point"
         validated = ggsql.validate(query)
+        assert validated.valid()
         assert validated.has_visual()
         assert validated.sql() == "SELECT * FROM test_data"
         assert validated.visual() == "VISUALISE x, y DRAW point"
@@ -73,9 +75,11 @@ class TestGgsqlValidate:
         )
         validated = ggsql.validate(query)
         assert not validated.valid()
+        messages = [error["message"] for error in validated.errors()]
         assert any(
-            "Mappings accept column names only" in error["message"]
-            for error in validated.errors()
+            "VISUALISE clause was not recognized" in message
+            and "column names only" in message
+            for message in messages
         )
 
     def test_splits_query_with_visualise(self):

--- a/pkg-py/tests/test_viz_tools.py
+++ b/pkg-py/tests/test_viz_tools.py
@@ -189,6 +189,18 @@ class TestToolVisualize:
         assert "Move data transformations to the SELECT clause" in str(result.error)
 
     @pytest.mark.ggsql
+    def test_tool_invalid_geom_uses_fallback_error(self, data_source):
+        tool = tool_visualize(data_source, lambda _: None)
+        result = tool.func(
+            ggsql="SELECT x FROM test_data VISUALISE x DRAW nope",
+            title="Bad Viz",
+        )
+
+        assert result.error is not None
+        assert "Mappings accept column names only" not in str(result.error)
+        assert "Parse error" in str(result.error)
+
+    @pytest.mark.ggsql
     def test_tool_still_rejects_query_without_visualise(self, data_source):
         tool = tool_visualize(data_source, lambda _: None)
         result = tool.func(ggsql="SELECT x, y FROM test_data", title="No Viz")

--- a/pkg-py/tests/test_viz_tools.py
+++ b/pkg-py/tests/test_viz_tools.py
@@ -171,6 +171,32 @@ class TestToolVisualize:
         assert result.error is not None
         assert "VISUALISE" in str(result.error)
 
+    @pytest.mark.ggsql
+    def test_tool_surfaces_upstream_expression_in_visualise_error(self, data_source):
+        tool = tool_visualize(data_source, lambda _: None)
+        result = tool.func(
+            ggsql=(
+                "SELECT CAST(x AS DOUBLE) AS x2, y "
+                "FROM test_data "
+                "VISUALISE CAST(x2 AS DOUBLE) AS x, y "
+                "DRAW point"
+            ),
+            title="Bad Viz",
+        )
+
+        assert result.error is not None
+        assert "Mappings accept column names only" in str(result.error)
+        assert "Move data transformations to the SELECT clause" in str(result.error)
+
+    @pytest.mark.ggsql
+    def test_tool_still_rejects_query_without_visualise(self, data_source):
+        tool = tool_visualize(data_source, lambda _: None)
+        result = tool.func(ggsql="SELECT x, y FROM test_data", title="No Viz")
+
+        assert result.error is not None
+        assert "Query must include a VISUALISE clause" in str(result.error)
+        assert "Use querychat_query" in str(result.error)
+
 
 class TestVisualizeResultContent:
     @pytest.mark.ggsql

--- a/pkg-py/tests/test_viz_tools.py
+++ b/pkg-py/tests/test_viz_tools.py
@@ -6,6 +6,7 @@ import narwhals.stable.v1 as nw
 import polars as pl
 import pytest
 from querychat._datasource import DataFrameSource
+from querychat._utils import read_prompt_template
 from querychat.tools import tool_visualize
 from querychat.types import VisualizeData, VisualizeResult
 
@@ -75,15 +76,20 @@ class TestToolVisualize:
         tool = tool_visualize(data_source, update_fn)
         assert tool.name == "querychat_visualize"
 
-    def test_visualize_tool_prompt_mentions_current_ggsql_rules(self, data_source):
-        tool = tool_visualize(data_source, lambda _: None)
-        doc = tool.func.__doc__
+    def test_visualize_tool_prompt_mentions_current_ggsql_rules(self):
+        doc = read_prompt_template("tool-visualize.md", db_type="DuckDB")
 
-        assert "DRAW range" in doc or "range" in doc
-        assert "read the error message carefully" in doc
-        assert "Do NOT include `LABEL title => ...`" in doc
-        assert "VISUALISE and MAPPING accept column names only" in doc
-        assert "querychat-specific parser compensation" not in doc
+        assert "All data transformations must happen in the `SELECT` clause." in doc
+        assert (
+            "`VISUALISE` and `MAPPING` accept column names only, not SQL expressions "
+            "or functions."
+        ) in doc
+        assert "Do NOT include `LABEL title => ...` in the query" in doc
+        assert "read the error message carefully and retry with a corrected query" in doc
+        assert (
+            "using `DRAW range` for interval-style marks instead of deprecated "
+            "`errorbar`"
+        ) in doc
 
     @pytest.mark.ggsql
     def test_tool_executes_sql_and_renders(self, data_source, monkeypatch):

--- a/pkg-py/tests/test_viz_tools.py
+++ b/pkg-py/tests/test_viz_tools.py
@@ -1,6 +1,7 @@
 """Tests for visualization tool functions."""
 
 import importlib.util
+from pathlib import Path
 
 import narwhals.stable.v1 as nw
 import polars as pl
@@ -47,6 +48,24 @@ class TestVizDependencyCheck:
         # Should not raise even though find_spec returns None for everything
         result = normalize_tools(("visualize",), default=None, check_deps=False)
         assert result == ("visualize",)
+
+
+def test_ggsql_syntax_reference_uses_range_not_errorbar():
+    syntax = Path("pkg-py/src/querychat/prompts/ggsql-syntax.md").read_text()
+    assert "`range`" in syntax
+    assert "`errorbar`" not in syntax
+
+
+def test_ggsql_syntax_reference_does_not_teach_one_ended_segment():
+    syntax = Path("pkg-py/src/querychat/prompts/ggsql-syntax.md").read_text()
+    assert "segment can omit one endpoint" not in syntax
+    assert "Requires `x`, `y`, `xend`, `yend`" in syntax or "Requires x, y, xend, yend" in syntax
+
+
+def test_main_prompt_still_embeds_ggsql_reference():
+    prompt = Path("pkg-py/src/querychat/prompts/prompt.md").read_text()
+    assert "{{> ggsql-syntax}}" in prompt
+    assert "querychat_visualize" in prompt
 
 
 @pytest.fixture

--- a/pkg-py/tests/test_viz_tools.py
+++ b/pkg-py/tests/test_viz_tools.py
@@ -75,6 +75,16 @@ class TestToolVisualize:
         tool = tool_visualize(data_source, update_fn)
         assert tool.name == "querychat_visualize"
 
+    def test_visualize_tool_prompt_mentions_current_ggsql_rules(self, data_source):
+        tool = tool_visualize(data_source, lambda _: None)
+        doc = tool.func.__doc__
+
+        assert "DRAW range" in doc or "range" in doc
+        assert "read the error message carefully" in doc
+        assert "Do NOT include `LABEL title => ...`" in doc
+        assert "VISUALISE and MAPPING accept column names only" in doc
+        assert "querychat-specific parser compensation" not in doc
+
     @pytest.mark.ggsql
     def test_tool_executes_sql_and_renders(self, data_source, monkeypatch):
         callback_data = {}

--- a/pkg-py/tests/test_viz_tools.py
+++ b/pkg-py/tests/test_viz_tools.py
@@ -189,7 +189,7 @@ class TestToolVisualize:
         assert "Move data transformations to the SELECT clause" in str(result.error)
 
     @pytest.mark.ggsql
-    def test_tool_invalid_geom_uses_fallback_error(self, data_source):
+    def test_tool_invalid_geom_passes_through_upstream_error(self, data_source):
         tool = tool_visualize(data_source, lambda _: None)
         result = tool.func(
             ggsql="SELECT x FROM test_data VISUALISE x DRAW nope",
@@ -197,8 +197,8 @@ class TestToolVisualize:
         )
 
         assert result.error is not None
-        assert "Mappings accept column names only" not in str(result.error)
-        assert "Parse error" in str(result.error)
+        assert "VISUALISE clause was not recognized" in str(result.error)
+        assert "Mappings accept column names only" in str(result.error)
 
     @pytest.mark.ggsql
     def test_tool_still_rejects_query_without_visualise(self, data_source):

--- a/pkg-py/tests/test_viz_tools.py
+++ b/pkg-py/tests/test_viz_tools.py
@@ -7,9 +7,12 @@ import narwhals.stable.v1 as nw
 import polars as pl
 import pytest
 from querychat._datasource import DataFrameSource
+from querychat._system_prompt import QueryChatSystemPrompt
 from querychat._utils import read_prompt_template
 from querychat.tools import tool_visualize
 from querychat.types import VisualizeData, VisualizeResult
+
+PROMPTS_DIR = Path(__file__).resolve().parents[1] / "src" / "querychat" / "prompts"
 
 
 class TestVizDependencyCheck:
@@ -51,21 +54,29 @@ class TestVizDependencyCheck:
 
 
 def test_ggsql_syntax_reference_uses_range_not_errorbar():
-    syntax = Path("pkg-py/src/querychat/prompts/ggsql-syntax.md").read_text()
+    syntax = (PROMPTS_DIR / "ggsql-syntax.md").read_text()
     assert "`range`" in syntax
     assert "`errorbar`" not in syntax
 
 
 def test_ggsql_syntax_reference_does_not_teach_one_ended_segment():
-    syntax = Path("pkg-py/src/querychat/prompts/ggsql-syntax.md").read_text()
+    syntax = (PROMPTS_DIR / "ggsql-syntax.md").read_text()
     assert "segment can omit one endpoint" not in syntax
     assert "Requires `x`, `y`, `xend`, `yend`" in syntax or "Requires x, y, xend, yend" in syntax
 
 
-def test_main_prompt_still_embeds_ggsql_reference():
-    prompt = Path("pkg-py/src/querychat/prompts/prompt.md").read_text()
-    assert "{{> ggsql-syntax}}" in prompt
+def test_main_prompt_render_includes_ggsql_reference(data_source):
+    system_prompt = QueryChatSystemPrompt(
+        PROMPTS_DIR / "prompt.md",
+        data_source=data_source,
+    )
+
+    prompt = system_prompt.render(("visualize",))
+
     assert "querychat_visualize" in prompt
+    assert "## ggsql Syntax Reference" in prompt
+    assert "`range` displays interval marks." in prompt
+    assert "{{> ggsql-syntax}}" not in prompt
 
 
 @pytest.fixture

--- a/pkg-py/tests/test_viz_tools.py
+++ b/pkg-py/tests/test_viz_tools.py
@@ -200,6 +200,30 @@ class TestToolVisualize:
         assert "VISUALISE clause was not recognized" in str(result.error)
         assert "Mappings accept column names only" in str(result.error)
 
+    def test_tool_joins_all_upstream_validation_errors(self, data_source, monkeypatch):
+        class FakeValidated:
+            def has_visual(self):
+                return True
+
+            def valid(self):
+                return False
+
+            def errors(self):
+                return [
+                    {"message": "first ggsql error"},
+                    {"message": "second ggsql error"},
+                ]
+
+        import ggsql
+
+        monkeypatch.setattr(ggsql, "validate", lambda _query: FakeValidated())
+
+        tool = tool_visualize(data_source, lambda _: None)
+        result = tool.func(ggsql="SELECT x VISUALISE x DRAW point", title="Bad Viz")
+
+        assert result.error is not None
+        assert str(result.error) == "first ggsql error\nsecond ggsql error"
+
     @pytest.mark.ggsql
     def test_tool_still_rejects_query_without_visualise(self, data_source):
         tool = tool_visualize(data_source, lambda _: None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dash = ["dash-ag-grid>=31.0", "dash[async]>=3.1", "dash-bootstrap-components>=2.
 # Visualization with ggsql
 viz = [
     # Temporary direct reference until ggsql 0.3.0 is available on the package index.
-    "ggsql @ git+https://github.com/cpsievert/ggsql-python.git@3a941bf5378cb3c12ac003fc92f2ff8e96ebb8dd",
+    "ggsql @ git+https://github.com/posit-dev/ggsql-python.git@refs/pull/5/head",
     "altair>=6.0",
     "shinywidgets>=0.8.0",
     "vl-convert-python>=1.9.0",
@@ -102,7 +102,7 @@ dev = [
     "pyarrow>=14.0.0",
     "ibis-framework[duckdb]>=9.0.0",
     # Temporary direct reference until ggsql 0.3.0 is available on the package index.
-    "ggsql @ git+https://github.com/cpsievert/ggsql-python.git@3a941bf5378cb3c12ac003fc92f2ff8e96ebb8dd",
+    "ggsql @ git+https://github.com/posit-dev/ggsql-python.git@refs/pull/5/head",
     "altair>=6.0",
     "shinywidgets>=0.8.0",
     "vl-convert-python>=1.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,13 @@ streamlit = ["streamlit>=1.30"]
 gradio = ["gradio>=6.0"]
 dash = ["dash-ag-grid>=31.0", "dash[async]>=3.1", "dash-bootstrap-components>=2.0", "pandas"]
 # Visualization with ggsql
-viz = ["ggsql>=0.3.0", "altair>=6.0", "shinywidgets>=0.8.0", "vl-convert-python>=1.9.0"]
+viz = [
+    # Temporary direct reference until ggsql 0.3.0 is available on the package index.
+    "ggsql @ git+https://github.com/cpsievert/ggsql-python.git@3a941bf5378cb3c12ac003fc92f2ff8e96ebb8dd",
+    "altair>=6.0",
+    "shinywidgets>=0.8.0",
+    "vl-convert-python>=1.9.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/posit-dev/querychat" # TODO update when we have docs
@@ -87,7 +93,20 @@ git_describe_command = "git describe --dirty --tags --long --match 'py/v*'"
 version-file = "pkg-py/src/querychat/__version.py"
 
 [dependency-groups]
-dev = ["ruff>=0.6.5", "pyright>=1.1.401", "tox-uv>=1.11.4", "pytest>=8.4.0", "polars>=1.0.0", "pyarrow>=14.0.0", "ibis-framework[duckdb]>=9.0.0", "ggsql>=0.3.0", "altair>=6.0", "shinywidgets>=0.8.0", "vl-convert-python>=1.9.0"]
+dev = [
+    "ruff>=0.6.5",
+    "pyright>=1.1.401",
+    "tox-uv>=1.11.4",
+    "pytest>=8.4.0",
+    "polars>=1.0.0",
+    "pyarrow>=14.0.0",
+    "ibis-framework[duckdb]>=9.0.0",
+    # Temporary direct reference until ggsql 0.3.0 is available on the package index.
+    "ggsql @ git+https://github.com/cpsievert/ggsql-python.git@3a941bf5378cb3c12ac003fc92f2ff8e96ebb8dd",
+    "altair>=6.0",
+    "shinywidgets>=0.8.0",
+    "vl-convert-python>=1.9.0",
+]
 docs = ["quartodoc>=0.11.1", "griffe<2", "nbformat", "nbclient", "ipykernel"]
 examples = [
     "openai",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ streamlit = ["streamlit>=1.30"]
 gradio = ["gradio>=6.0"]
 dash = ["dash-ag-grid>=31.0", "dash[async]>=3.1", "dash-bootstrap-components>=2.0", "pandas"]
 # Visualization with ggsql
-viz = ["ggsql>=0.2.4", "altair>=6.0", "shinywidgets>=0.8.0", "vl-convert-python>=1.9.0"]
+viz = ["ggsql>=0.3.0", "altair>=6.0", "shinywidgets>=0.8.0", "vl-convert-python>=1.9.0"]
 
 [project.urls]
 Homepage = "https://github.com/posit-dev/querychat" # TODO update when we have docs
@@ -87,7 +87,7 @@ git_describe_command = "git describe --dirty --tags --long --match 'py/v*'"
 version-file = "pkg-py/src/querychat/__version.py"
 
 [dependency-groups]
-dev = ["ruff>=0.6.5", "pyright>=1.1.401", "tox-uv>=1.11.4", "pytest>=8.4.0", "polars>=1.0.0", "pyarrow>=14.0.0", "ibis-framework[duckdb]>=9.0.0", "ggsql>=0.2.4", "altair>=6.0", "shinywidgets>=0.8.0", "vl-convert-python>=1.9.0"]
+dev = ["ruff>=0.6.5", "pyright>=1.1.401", "tox-uv>=1.11.4", "pytest>=8.4.0", "polars>=1.0.0", "pyarrow>=14.0.0", "ibis-framework[duckdb]>=9.0.0", "ggsql>=0.3.0", "altair>=6.0", "shinywidgets>=0.8.0", "vl-convert-python>=1.9.0"]
 docs = ["quartodoc>=0.11.1", "griffe<2", "nbformat", "nbclient", "ipykernel"]
 examples = [
     "openai",


### PR DESCRIPTION
Follow up to #201 

## Summary

- bump Python ggsql dependency metadata to `>=0.3.0`
- refresh ggsql prompt/tool guidance and syntax references for `range`, full `segment` endpoints, and `FROM ... VISUALISE ...`
- simplify `_viz_tools.py` to use ggsql 0.3 validation where safe, with regression coverage for malformed visual queries

## Test Plan
- [x] `.venv/bin/pytest pkg-py/tests/test_viz_tools.py pkg-py/tests/test_ggsql.py -v`
- [x] `.venv/bin/ruff check pkg-py/src/querychat/_viz_tools.py pkg-py/tests/test_viz_tools.py pkg-py/tests/test_ggsql.py`

## Notes
- Local verification used the draft package from `../ggsql-python` installed into the worktree venv.
- Fresh `uv run` resolution is still blocked until `ggsql>=0.3.0` is available on the normal resolver path.
