### PR TITLE
chore(pkg-py): remove stale ggsql casing guidance

### DIFF
--- a/pkg-py/src/querychat/_viz_ggsql.py
+++ b/pkg-py/src/querychat/_viz_ggsql.py
@@ -48,10 +48,6 @@ def execute_ggsql(data_source: DataSource, validated: ggsql.Validated) -> ggsql.
         )
 
     pl_df = to_polars(data_source.execute_query(validated.sql()))
-    # Snowflake (and some other backends) uppercase unquoted identifiers,
-    # but the LLM writes lowercase aliases in the VISUALISE clause.
-    # DuckDB is case-insensitive, so lowercasing here lets both match.
-    pl_df.columns = [c.lower() for c in pl_df.columns]
 
     reader = DuckDBReader("duckdb://memory")
     table = extract_visualise_table(visual)

--- a/pkg-py/src/querychat/prompts/ggsql-syntax.md
+++ b/pkg-py/src/querychat/prompts/ggsql-syntax.md
@@ -536,22 +536,8 @@ PROJECT TO polar SETTING inner => 0.5
     DRAW line MAPPING region AS color FILTER layer_type = 'summary'
     ```
 4. **String values use single quotes**: In SETTING, LABEL, and RENAMING clauses, always use single quotes for string values. Double quotes cause parse errors.
-5. **Column casing in VISUALISE**: DuckDB lowercases unquoted column names in query results, and VISUALISE validates column references **case-sensitively**. If your source table has uppercase column names (e.g., from Snowflake), you **must** alias them to lowercase in the SELECT clause:
-   ```sql
-   -- WRONG: VISUALISE references uppercase name, but DuckDB lowercases it in results
-   SELECT ROOM_TYPE, COUNT(*) AS listings FROM airbnb
-   VISUALISE ROOM_TYPE AS x, listings AS y
-   DRAW bar
-
-   -- CORRECT: Alias to lowercase, then reference the alias
-   SELECT ROOM_TYPE AS room_type, COUNT(*) AS listings FROM airbnb
-   VISUALISE room_type AS x, listings AS y
-   DRAW bar
-   ```
-   As a general rule, always use lowercase column names and aliases in both SELECT and VISUALISE clauses.
-6. **Charts vs Tables**: For visualizations use VISUALISE with DRAW. For tabular data use plain SQL without VISUALISE.
-7. **Statistical layers**: When using `histogram`, `bar` (without y), `density`, `smooth`, `violin`, or `boxplot`, the layer computes statistics. Use REMAPPING to access `density`, `intensity`, `proportion`, etc.
-8. **No trailing commas**: SETTING, LABEL, MAPPING, and RENAMING clauses must not end with a trailing comma. A comma after the last item causes a parse error.
+5. **Statistical layers**: When using `histogram`, `bar` (without y), `density`, `smooth`, `violin`, or `boxplot`, the layer computes statistics. Use REMAPPING to access `density`, `intensity`, `proportion`, etc.
+6. **No trailing commas**: SETTING, LABEL, MAPPING, and RENAMING clauses must not end with a trailing comma. A comma after the last item causes a parse error.
    ```sql
    -- WRONG: trailing comma after the last label
    LABEL x => 'Gender', y => 'Count',

--- a/pkg-py/src/querychat/prompts/ggsql-syntax.md
+++ b/pkg-py/src/querychat/prompts/ggsql-syntax.md
@@ -545,7 +545,7 @@ PROJECT TO polar SETTING inner => 0.5
    -- CORRECT
    LABEL x => 'Gender', y => 'Count'
    ```
-9. **Bar position adjustments**: Bars stack automatically when `fill` is mapped. Use `SETTING position => 'dodge'` for side-by-side bars, or `position => 'stack', total => 1` for proportional (100%) stacking:
+7. **Bar position adjustments**: Bars stack automatically when `fill` is mapped. Use `SETTING position => 'dodge'` for side-by-side bars, or `position => 'stack', total => 1` for proportional (100%) stacking:
    ```sql
    DRAW bar MAPPING category AS x, subcategory AS fill                                          -- stacked (default)
    DRAW bar MAPPING category AS x, subcategory AS fill SETTING position => 'dodge'              -- side-by-side

--- a/pkg-py/tests/test_ggsql.py
+++ b/pkg-py/tests/test_ggsql.py
@@ -17,7 +17,10 @@ class TestExtractVisualiseTable:
     """Tests for extract_visualise_table() parsing."""
 
     def test_bare_identifier(self):
-        assert extract_visualise_table("VISUALISE x, y FROM mytable DRAW point") == "mytable"
+        assert (
+            extract_visualise_table("VISUALISE x, y FROM mytable DRAW point")
+            == "mytable"
+        )
 
     def test_quoted_identifier(self):
         assert (
@@ -112,7 +115,6 @@ class TestGgsqlValidate:
         assert "LABEL title" in validated.visual()
 
 
-
 @pytest.fixture(autouse=True)
 def _allow_widget_outside_session(monkeypatch):
     """Allow JupyterChart (an ipywidget) to be constructed without a Shiny session."""
@@ -187,6 +189,63 @@ class TestExecuteGgsql:
         altair_widget = AltairWidget.from_ggsql(spec)
         result = altair_widget.widget.chart.to_dict()
         assert "$schema" in result
+
+    @pytest.mark.ggsql
+    def test_supports_uppercase_column_references_without_renaming(self):
+        nw_df = nw.from_native(
+            pl.DataFrame(
+                {
+                    "ROOM_TYPE": ["Entire home", "Private room"],
+                    "listings": [10, 20],
+                }
+            )
+        )
+        ds = DataFrameSource(nw_df, "upper_table")
+        query = (
+            "SELECT ROOM_TYPE, listings FROM upper_table "
+            "VISUALISE ROOM_TYPE AS x, listings AS y "
+            "DRAW bar"
+        )
+        spec = execute_ggsql(ds, ggsql.validate(query))
+        assert "VISUALISE" in spec.visual()
+
+    def test_passes_original_column_names_through_to_ggsql(self, monkeypatch):
+        nw_df = nw.from_native(
+            pl.DataFrame(
+                {
+                    "ROOM_TYPE": ["Entire home", "Private room"],
+                    "listings": [10, 20],
+                }
+            )
+        )
+        ds = DataFrameSource(nw_df, "upper_table")
+        validated = type(
+            "Validated",
+            (),
+            {
+                "sql": lambda self: "SELECT ROOM_TYPE, listings FROM upper_table",
+                "visual": lambda self: (
+                    "VISUALISE ROOM_TYPE AS x, listings AS y DRAW bar"
+                ),
+            },
+        )()
+        captured_columns = None
+
+        class FakeReader:
+            def register(self, name, df):
+                nonlocal captured_columns
+                captured_columns = list(df.columns)
+
+            def execute(self, query):
+                return type("Spec", (), {"visual": lambda self: query})()
+
+        import ggsql
+
+        monkeypatch.setattr(ggsql, "DuckDBReader", lambda *_args: FakeReader())
+
+        spec = execute_ggsql(ds, validated)
+        assert "VISUALISE" in spec.visual()
+        assert captured_columns == ["ROOM_TYPE", "listings"]
 
     @pytest.mark.ggsql
     def test_rejects_layer_level_from_sources_with_clear_error(self):

--- a/pkg-py/tests/test_viz_tools.py
+++ b/pkg-py/tests/test_viz_tools.py
@@ -42,9 +42,7 @@ class TestVizDependencyCheck:
 
     def test_check_deps_false_skips_check(self, monkeypatch):
         """check_deps=False should skip the dependency check."""
-        monkeypatch.setattr(
-            importlib.util, "find_spec", lambda name, *a, **kw: None
-        )
+        monkeypatch.setattr(importlib.util, "find_spec", lambda name, *a, **kw: None)
 
         from querychat._querychat_base import normalize_tools
 
@@ -62,7 +60,21 @@ def test_ggsql_syntax_reference_uses_range_not_errorbar():
 def test_ggsql_syntax_reference_does_not_teach_one_ended_segment():
     syntax = (PROMPTS_DIR / "ggsql-syntax.md").read_text()
     assert "segment can omit one endpoint" not in syntax
-    assert "Requires `x`, `y`, `xend`, `yend`" in syntax or "Requires x, y, xend, yend" in syntax
+    assert (
+        "Requires `x`, `y`, `xend`, `yend`" in syntax
+        or "Requires x, y, xend, yend" in syntax
+    )
+
+
+def test_ggsql_syntax_reference_does_not_teach_stale_column_casing_workaround():
+    syntax = (PROMPTS_DIR / "ggsql-syntax.md").read_text()
+    assert "Column casing in VISUALISE" not in syntax
+    assert "ROOM_TYPE" not in syntax
+
+
+def test_ggsql_syntax_reference_does_not_repeat_charts_vs_tables_note():
+    syntax = (PROMPTS_DIR / "ggsql-syntax.md").read_text()
+    assert "**Charts vs Tables**" not in syntax
 
 
 def test_main_prompt_render_includes_ggsql_reference(data_source):
@@ -76,6 +88,8 @@ def test_main_prompt_render_includes_ggsql_reference(data_source):
     assert "querychat_visualize" in prompt
     assert "## ggsql Syntax Reference" in prompt
     assert "`range` displays interval marks." in prompt
+    assert "Column casing in VISUALISE" not in prompt
+    assert "ROOM_TYPE" not in prompt
     assert "{{> ggsql-syntax}}" not in prompt
 
 
@@ -115,7 +129,9 @@ class TestToolVisualize:
             "or functions."
         ) in doc
         assert "Do NOT include `LABEL title => ...` in the query" in doc
-        assert "read the error message carefully and retry with a corrected query" in doc
+        assert (
+            "read the error message carefully and retry with a corrected query" in doc
+        )
         assert (
             "using `DRAW range` for interval-style marks instead of deprecated "
             "`errorbar`"
@@ -132,7 +148,9 @@ class TestToolVisualize:
 
         from ipywidgets.widgets.widget import Widget
 
-        monkeypatch.setattr("shinywidgets.register_widget", lambda _widget_id, _chart: None)
+        monkeypatch.setattr(
+            "shinywidgets.register_widget", lambda _widget_id, _chart: None
+        )
         monkeypatch.setattr(
             "shinywidgets.output_widget", lambda _widget_id, **_kwargs: MagicMock()
         )
@@ -325,8 +343,10 @@ class TestRenderChartToPng:
     def test_simple_chart_returns_bytes(self):
         import altair as alt
 
-        chart = alt.Chart({"values": [{"x": 1, "y": 2}]}).mark_point().encode(
-            x="x:Q", y="y:Q"
+        chart = (
+            alt.Chart({"values": [{"x": 1, "y": 2}]})
+            .mark_point()
+            .encode(x="x:Q", y="y:Q")
         )
         from querychat._viz_tools import render_chart_to_png
 


### PR DESCRIPTION
## Context
This is a follow-up to the earlier Python-side ggsql 0.3 prep work in #225.

That upgrade moved QueryChat onto the newer ggsql validation and syntax behavior, but it left behind one stale workaround from the pre-0.3 era: guidance and execution logic that assumed ggsql column references in `VISUALISE` were effectively case-sensitive and therefore needed QueryChat to normalize or teach lowercase aliases.

In other words, this is effectively a follow-up to a follow-up:
- #225 updated QueryChat for ggsql 0.3 semantics
- this PR finishes the casing-related cleanup that should have come along with that upgrade

Current ggsql now handles uppercase column references correctly, so QueryChat no longer needs to:
- lowercase dataframe columns before registering them with ggsql
- teach the model a special `ROOM_TYPE`/lowercase-alias workaround
- repeat the redundant charts-vs-tables note in the ggsql syntax reference

## Summary
- remove the stale column-casing workaround from Python ggsql execution
- remove obsolete casing/charts-vs-tables guidance from the Python ggsql syntax prompt
- add regression tests for uppercase column support and prompt cleanup

## Testing
- uv run pytest -q pkg-py/tests/test_viz_tools.py pkg-py/tests/test_ggsql.py -p no:playwright
- uv run ruff check pkg-py/src/querychat/_viz_ggsql.py pkg-py/tests/test_ggsql.py pkg-py/tests/test_viz_tools.py --config pyproject.toml