### PR TITLE
fix: visualize fullscreen layout

### DIFF
--- a/js/src/viz.css
+++ b/js/src/viz.css
@@ -11,7 +11,7 @@
 }
 
 /* In full-screen mode, let the chart fill the available space */
-.bslib-full-screen-container .querychat-viz-container {
+.shiny-tool-card[fullscreen] .querychat-viz-container {
   aspect-ratio: unset;
 }
 
@@ -128,6 +128,14 @@
 .shiny-tool-card:has(.querychat-viz-container) {
   max-height: 700px;
   overflow: hidden;
+}
+
+.shiny-tool-card:has(.querychat-viz-container) > .card-footer {
+  flex: 0 0 auto;
+}
+
+.shiny-tool-card[fullscreen]:has(.querychat-viz-container) {
+  max-height: none;
 }
 
 .querychat-query-section bslib-code-editor .code-editor {

--- a/pkg-py/src/querychat/static/css/viz.css
+++ b/pkg-py/src/querychat/static/css/viz.css
@@ -12,7 +12,7 @@
 }
 
 /* In full-screen mode, let the chart fill the available space */
-.bslib-full-screen-container .querychat-viz-container {
+.shiny-tool-card[fullscreen] .querychat-viz-container {
   aspect-ratio: unset;
 }
 
@@ -129,6 +129,14 @@
 .shiny-tool-card:has(.querychat-viz-container) {
   max-height: 700px;
   overflow: hidden;
+}
+
+.shiny-tool-card:has(.querychat-viz-container) > .card-footer {
+  flex: 0 0 auto;
+}
+
+.shiny-tool-card[fullscreen]:has(.querychat-viz-container) {
+  max-height: none;
 }
 
 .querychat-query-section bslib-code-editor .code-editor {

--- a/pkg-py/tests/playwright/test_10_viz_inline.py
+++ b/pkg-py/tests/playwright/test_10_viz_inline.py
@@ -105,6 +105,59 @@ class TestInlineVisualization:
         # Fullscreen should be removed
         expect(card).not_to_be_visible()
 
+    def test_fullscreen_uses_available_height_in_tall_viewport(self) -> None:
+        """VIZ-FS-HEIGHT: Fullscreen viz cards should fill tall, narrow viewports."""
+        self.page.set_viewport_size({"width": 900, "height": 1600})
+
+        self.chat.set_user_input(
+            "Make a bar chart showing count of passengers by class and age group"
+        )
+        self.chat.send_user_input(method="click")
+
+        tool_result = self.page.locator(".shiny-tool-result:has(.tool-fullscreen-toggle)")
+        expect(tool_result).to_be_visible(timeout=90000)
+
+        tool_result.locator(".tool-fullscreen-toggle").click()
+
+        card = tool_result.locator(".shiny-tool-card[fullscreen]")
+        expect(card).to_be_visible()
+
+        viz_container = card.locator(".querychat-viz-container")
+        expect(viz_container).to_be_visible(timeout=10000)
+
+        viewport_height = self.page.viewport_size["height"]
+        card_box = card.bounding_box()
+        viz_box = viz_container.bounding_box()
+
+        assert card_box is not None
+        assert viz_box is not None
+        assert card_box["height"] > viewport_height * 0.9
+        assert viz_box["height"] > viewport_height * 0.5
+
+    def test_fullscreen_footer_does_not_stretch(self) -> None:
+        """VIZ-FS-FOOTER: Fullscreen viz footers should remain content-height."""
+        self.page.set_viewport_size({"width": 1600, "height": 1336})
+
+        self.chat.set_user_input(
+            "Create a stacked bar chart of number of passengers by sex and class"
+        )
+        self.chat.send_user_input(method="click")
+
+        tool_result = self.page.locator(".shiny-tool-result:has(.tool-fullscreen-toggle)")
+        expect(tool_result).to_be_visible(timeout=90000)
+
+        tool_result.locator(".tool-fullscreen-toggle").click()
+
+        card = tool_result.locator(".shiny-tool-card[fullscreen]")
+        expect(card).to_be_visible()
+
+        footer = card.locator(":scope > .card-footer")
+        expect(footer).to_be_visible(timeout=10000)
+
+        footer_box = footer.bounding_box()
+        assert footer_box is not None
+        assert footer_box["height"] < 100
+
     def test_non_viz_tool_results_have_no_fullscreen(self) -> None:
         """VIZ-NO-FS: Non-visualization tool results don't have fullscreen."""
         self.chat.set_user_input("Show me passengers who survived")


### PR DESCRIPTION
## Summary
Fix the visualize tool's fullscreen card layout so charts can use the full viewport height without the footer stretching to consume leftover space.
Simplify the fullscreen-specific CSS to the selectors and rules that are actually needed for the shinychat-based fullscreen path.
Add Playwright regressions covering tall/narrow fullscreen sizing and non-stretching fullscreen footers.

## Verification
uv run ruff check --fix pkg-py --config pyproject.toml
make py-check-types
make py-check-tests
uv run pytest pkg-py/tests/playwright/test_10_viz_inline.py::TestInlineVisualization::test_fullscreen_uses_available_height_in_tall_viewport -q
uv run pytest pkg-py/tests/playwright/test_10_viz_inline.py::TestInlineVisualization::test_fullscreen_footer_does_not_stretch -q