### PR TITLE
fix: replace nested suggestion lists with heading-grouped flat lists

### DIFF
--- a/pkg-py/docs/greet.qmd
+++ b/pkg-py/docs/greet.qmd
@@ -21,15 +21,15 @@ app = qc.app()
 You can provide suggestions to the user by using the `<span class="suggestion"> </span>` tag:
 
 ```markdown
-* **Filter and sort the data:**
-  * <span class="suggestion">Show only survivors</span>
-  * <span class="suggestion">Filter to first class passengers under 30</span>
-  * <span class="suggestion">Sort by fare from highest to lowest</span>
+##### Filter and sort the data
+* <span class="suggestion">Show only survivors</span>
+* <span class="suggestion">Filter to first class passengers under 30</span>
+* <span class="suggestion">Sort by fare from highest to lowest</span>
 
-* **Answer questions about the data:**
-  * <span class="suggestion">What was the survival rate by gender?</span>
-  * <span class="suggestion">What's the average age of children who survived?</span>
-  * <span class="suggestion">How many passengers were traveling alone?</span>
+##### Answer questions about the data
+* <span class="suggestion">What was the survival rate by gender?</span>
+* <span class="suggestion">What's the average age of children who survived?</span>
+* <span class="suggestion">How many passengers were traveling alone?</span>
 ```
 
 These suggestions appear in the greeting and automatically populate the chat text box when clicked.

--- a/pkg-py/examples/greeting.md
+++ b/pkg-py/examples/greeting.md
@@ -1,13 +1,15 @@
 Hello! Welcome to your Titanic data dashboard. I'm here to help you filter, sort, and analyze the data. Here are a few ideas to get you started:
 
-* Explore the data
-  * <span class="suggestion">Show me all passengers who survived</span>
-  * <span class="suggestion">Show only first class passengers</span>
-* Analyze statistics
-  * <span class="suggestion">What is the average age of passengers?</span>
-  * <span class="suggestion">How many children were on board?</span>
-* Compare and dig deeper
-  * <span class="suggestion">Which class had the highest survival rate?</span>
-  * <span class="suggestion">Show the fare distribution by embarkation town</span>
+##### Explore the data
+* <span class="suggestion">Show me all passengers who survived</span>
+* <span class="suggestion">Show only first class passengers</span>
+
+##### Analyze statistics
+* <span class="suggestion">What is the average age of passengers?</span>
+* <span class="suggestion">How many children were on board?</span>
+
+##### Compare and dig deeper
+* <span class="suggestion">Which class had the highest survival rate?</span>
+* <span class="suggestion">Show the fare distribution by embarkation town</span>
 
 Let me know what you'd like to explore!

--- a/pkg-py/src/querychat/_querychat_core.py
+++ b/pkg-py/src/querychat/_querychat_core.py
@@ -25,7 +25,7 @@ from .tools import UpdateDashboardData
 
 GREETING_PROMPT: str = (
     "Please give me a friendly greeting. "
-    "Include a few sample prompts in a two-level bulleted list."
+    "Include a few sample prompts grouped under headings."
 )
 """Prompt used to generate the initial greeting message."""
 

--- a/pkg-py/src/querychat/prompts/prompt.md
+++ b/pkg-py/src/querychat/prompts/prompt.md
@@ -228,21 +228,23 @@ Use `<span class="suggestion">` tags to create clickable prompt buttons in the U
 You might want to <span class="suggestion">explore the advanced features</span> or <span class="suggestion">show me a practical example</span>.
 ```
 
-**Nested lists:**
+**Grouped suggestions:**
 ```md
 {{#has_tool_query}}
-* Analyze the data
-  * <span class="suggestion">What's the average …?</span>
-  * <span class="suggestion">How many …?</span>
+##### Analyze the data
+* <span class="suggestion">What's the average …?</span>
+* <span class="suggestion">How many …?</span>
+
 {{/has_tool_query}}
 {{#has_tool_visualize}}
-* Visualize the data
-  * <span class="suggestion">Show a bar chart of …</span>
-  * <span class="suggestion">Plot the trend of … over time</span>
+##### Visualize the data
+* <span class="suggestion">Show a bar chart of …</span>
+* <span class="suggestion">Plot the trend of … over time</span>
+
 {{/has_tool_visualize}}
-* Filter and sort
-  * <span class="suggestion">Show records from the year …</span>
-  * <span class="suggestion">Sort the ____ by ____ …</span>
+##### Filter and sort
+* <span class="suggestion">Show records from the year …</span>
+* <span class="suggestion">Sort the ____ by ____ …</span>
 ```
 
 #### When to Include Suggestions
@@ -264,6 +266,7 @@ You might want to <span class="suggestion">explore the advanced features</span> 
 
 - Suggestions can appear **anywhere** in your response—not just at the end
 - Use list format at the end for 2-4 follow-up options (most common pattern)
+- Never use nested lists for suggestions — group them under headings instead
 - Use inline suggestions within prose when contextually appropriate
 - Write suggestions as complete, natural prompts (not fragments)
 - Only suggest actions you can perform with your tools and capabilities

--- a/pkg-r/DESCRIPTION
+++ b/pkg-r/DESCRIPTION
@@ -55,4 +55,4 @@ Config/testthat/edition: 3
 Config/testthat/parallel: true
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -146,4 +146,4 @@ mod_server <- function(
 }
 
 # TODO: Make this dependent on enabled tools
-GREETING_PROMPT <- "Please give me a friendly greeting. Include a few sample prompts in a two-level bulleted list."
+GREETING_PROMPT <- "Please give me a friendly greeting. Include a few sample prompts grouped under headings."

--- a/pkg-r/inst/examples-shiny/02-sidebar-app/app.R
+++ b/pkg-r/inst/examples-shiny/02-sidebar-app/app.R
@@ -10,10 +10,12 @@ greeting <- r"(
 I can help you explore and analyze the Palmer Penguins dataset. Ask me questions
 about the penguins, and I'll generate SQL queries to get the answers.
 
-Try asking:
+##### Explore the data
 - <span class="suggestion">Show me the first 10 rows of the penguins dataset</span>
-- <span class="suggestion">What's the average bill length by species?</span>
 - <span class="suggestion">Which species has the largest body mass?</span>
+
+##### Analyze statistics
+- <span class="suggestion">What's the average bill length by species?</span>
 - <span class="suggestion">Create a summary of measurements grouped by species and island</span>
 )"
 

--- a/pkg-r/inst/examples-shiny/03-module-app/app.R
+++ b/pkg-r/inst/examples-shiny/03-module-app/app.R
@@ -10,7 +10,7 @@ greeting <- r"(
 I can help you explore and analyze the Palmer Penguins dataset. Ask me questions
 about the penguins, and I'll generate SQL queries to get the answers.
 
-Try asking:
+##### Explore the data
 - <span class="suggestion">Show me the first 10 rows of the penguins dataset</span>
 - <span class="suggestion">What's the average bill length by species?</span>
 - <span class="suggestion">Which species has the largest body mass?</span>

--- a/pkg-r/inst/examples-shiny/sqlite/app.R
+++ b/pkg-r/inst/examples-shiny/sqlite/app.R
@@ -26,10 +26,12 @@ greeting <- "
 I can help you explore and analyze the Palmer Penguins dataset from the connected database.
 Ask me questions about the penguins, and I'll generate SQL queries to get the answers.
 
-Try asking:
+##### Explore the data
 - <span class=\"suggestion\">Show me the first 10 rows of the penguins dataset</span>
-- <span class=\"suggestion\">What's the average bill length by species?</span>
 - <span class=\"suggestion\">Which species has the largest body mass?</span>
+
+##### Analyze statistics
+- <span class=\"suggestion\">What's the average bill length by species?</span>
 - <span class=\"suggestion\">Create a summary of measurements grouped by species and island</span>
 "
 

--- a/pkg-r/inst/prompts/prompt.md
+++ b/pkg-r/inst/prompts/prompt.md
@@ -144,14 +144,15 @@ Use `<span class="suggestion">` tags to create clickable prompt buttons in the U
 You might want to <span class="suggestion">explore the advanced features</span> or <span class="suggestion">show me a practical example</span>.
 ```
 
-**Nested lists:**
+**Grouped suggestions:**
 ```md
-* Analyze the data
-  * <span class="suggestion">What's the average …?</span>
-  * <span class="suggestion">How many …?</span>
-* Filter and sort
-  * <span class="suggestion">Show records from the year …</span>
-  * <span class="suggestion">Sort the ____ by ____ …</span>
+##### Analyze the data
+* <span class="suggestion">What's the average …?</span>
+* <span class="suggestion">How many …?</span>
+
+##### Filter and sort
+* <span class="suggestion">Show records from the year …</span>
+* <span class="suggestion">Sort the ____ by ____ …</span>
 ```
 
 #### When to Include Suggestions
@@ -173,6 +174,7 @@ You might want to <span class="suggestion">explore the advanced features</span> 
 
 - Suggestions can appear **anywhere** in your response—not just at the end
 - Use list format at the end for 2-4 follow-up options (most common pattern)
+- Never use nested lists for suggestions — group them under headings instead
 - Use inline suggestions within prose when contextually appropriate
 - Write suggestions as complete, natural prompts (not fragments)
 - Only suggest actions you can perform with your tools and capabilities

--- a/pkg-r/man/DBISource.Rd
+++ b/pkg-r/man/DBISource.Rd
@@ -4,11 +4,6 @@
 \alias{DBISource}
 \title{DBI Source}
 \description{
-DBI Source
-
-DBI Source
-}
-\details{
 A DataSource implementation for DBI database connections (SQLite, PostgreSQL,
 MySQL, etc.). This class wraps a DBI connection and provides SQL query
 execution against a single table in the database.
@@ -34,176 +29,192 @@ db_source$cleanup()
 \dontshow{\}) # examplesIf}
 }
 \section{Super class}{
-\code{\link[querychat:DataSource]{querychat::DataSource}} -> \code{DBISource}
+\code{\link[querychat:DataSource]{DataSource}} -> \code{DBISource}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-DBISource-new}{\code{DBISource$new()}}
-\item \href{#method-DBISource-get_db_type}{\code{DBISource$get_db_type()}}
-\item \href{#method-DBISource-get_schema}{\code{DBISource$get_schema()}}
-\item \href{#method-DBISource-get_semantic_views_description}{\code{DBISource$get_semantic_views_description()}}
-\item \href{#method-DBISource-execute_query}{\code{DBISource$execute_query()}}
-\item \href{#method-DBISource-test_query}{\code{DBISource$test_query()}}
-\item \href{#method-DBISource-get_data}{\code{DBISource$get_data()}}
-\item \href{#method-DBISource-cleanup}{\code{DBISource$cleanup()}}
-\item \href{#method-DBISource-clone}{\code{DBISource$clone()}}
-}
+  \itemize{
+    \item \href{#method-DBISource-initialize}{\code{DBISource$new()}}
+    \item \href{#method-DBISource-get_db_type}{\code{DBISource$get_db_type()}}
+    \item \href{#method-DBISource-get_schema}{\code{DBISource$get_schema()}}
+    \item \href{#method-DBISource-get_semantic_views_description}{\code{DBISource$get_semantic_views_description()}}
+    \item \href{#method-DBISource-execute_query}{\code{DBISource$execute_query()}}
+    \item \href{#method-DBISource-test_query}{\code{DBISource$test_query()}}
+    \item \href{#method-DBISource-get_data}{\code{DBISource$get_data()}}
+    \item \href{#method-DBISource-cleanup}{\code{DBISource$cleanup()}}
+    \item \href{#method-DBISource-clone}{\code{DBISource$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-DBISource-new"></a>}}
-\if{latex}{\out{\hypertarget{method-DBISource-new}{}}}
-\subsection{Method \code{new()}}{
-Create a new DBISource
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DBISource$new(conn, table_name)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{conn}}{A DBI connection object}
-
-\item{\code{table_name}}{Name of the table in the database. Can be a character
+\if{html}{\out{<a id="method-DBISource-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-DBISource-initialize}{}}}
+\subsection{\code{DBISource$new()}}{
+  Create a new DBISource
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DBISource$new(conn, table_name)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{conn}}{A DBI connection object}
+      \item{\code{table_name}}{Name of the table in the database. Can be a character
 string or a \code{\link[DBI:Id]{DBI::Id()}} object for tables in catalogs/schemas}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A new DBISource object
+  }
 }
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A new DBISource object
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DBISource-get_db_type"></a>}}
 \if{latex}{\out{\hypertarget{method-DBISource-get_db_type}{}}}
-\subsection{Method \code{get_db_type()}}{
-Get the database type
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DBISource$get_db_type()}\if{html}{\out{</div>}}
+\subsection{\code{DBISource$get_db_type()}}{
+  Get the database type
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DBISource$get_db_type()}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A string identifying the database type
+  }
 }
 
-\subsection{Returns}{
-A string identifying the database type
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DBISource-get_schema"></a>}}
 \if{latex}{\out{\hypertarget{method-DBISource-get_schema}{}}}
-\subsection{Method \code{get_schema()}}{
-Get schema information for the database table
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DBISource$get_schema(categorical_threshold = 20)}\if{html}{\out{</div>}}
+\subsection{\code{DBISource$get_schema()}}{
+  Get schema information for the database table
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DBISource$get_schema(categorical_threshold = 20)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{categorical_threshold}}{Maximum number of unique values for a text
+column to be considered categorical (default: 20)}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A string describing the schema
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{categorical_threshold}}{Maximum number of unique values for a text
-column to be considered categorical (default: 20)}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A string describing the schema
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DBISource-get_semantic_views_description"></a>}}
 \if{latex}{\out{\hypertarget{method-DBISource-get_semantic_views_description}{}}}
-\subsection{Method \code{get_semantic_views_description()}}{
-Get information about semantic views (if any) for the system prompt.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DBISource$get_semantic_views_description()}\if{html}{\out{</div>}}
+\subsection{\code{DBISource$get_semantic_views_description()}}{
+  Get information about semantic views (if any) for the system prompt.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DBISource$get_semantic_views_description()}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A string with semantic view information, or empty string if none
+  }
 }
 
-\subsection{Returns}{
-A string with semantic view information, or empty string if none
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DBISource-execute_query"></a>}}
 \if{latex}{\out{\hypertarget{method-DBISource-execute_query}{}}}
-\subsection{Method \code{execute_query()}}{
-Execute a SQL query
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DBISource$execute_query(query)}\if{html}{\out{</div>}}
+\subsection{\code{DBISource$execute_query()}}{
+  Execute a SQL query
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DBISource$execute_query(query)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{query}}{SQL query string. If NULL or empty, returns all data}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A data frame with query results
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{query}}{SQL query string. If NULL or empty, returns all data}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A data frame with query results
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DBISource-test_query"></a>}}
 \if{latex}{\out{\hypertarget{method-DBISource-test_query}{}}}
-\subsection{Method \code{test_query()}}{
-Test a SQL query by fetching only one row
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DBISource$test_query(query, require_all_columns = FALSE)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{query}}{SQL query string}
-
-\item{\code{require_all_columns}}{If \code{TRUE}, validates that the result includes
+\subsection{\code{DBISource$test_query()}}{
+  Test a SQL query by fetching only one row
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DBISource$test_query(query, require_all_columns = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{query}}{SQL query string}
+      \item{\code{require_all_columns}}{If \code{TRUE}, validates that the result includes
 all original table columns (default: \code{FALSE})}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A data frame with one row of results
+  }
 }
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A data frame with one row of results
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DBISource-get_data"></a>}}
 \if{latex}{\out{\hypertarget{method-DBISource-get_data}{}}}
-\subsection{Method \code{get_data()}}{
-Get all data from the table
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DBISource$get_data()}\if{html}{\out{</div>}}
+\subsection{\code{DBISource$get_data()}}{
+  Get all data from the table
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DBISource$get_data()}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A data frame containing all data
+  }
 }
 
-\subsection{Returns}{
-A data frame containing all data
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DBISource-cleanup"></a>}}
 \if{latex}{\out{\hypertarget{method-DBISource-cleanup}{}}}
-\subsection{Method \code{cleanup()}}{
-Disconnect from the database
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DBISource$cleanup()}\if{html}{\out{</div>}}
+\subsection{\code{DBISource$cleanup()}}{
+  Disconnect from the database
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DBISource$cleanup()}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    NULL (invisibly)
+  }
 }
 
-\subsection{Returns}{
-NULL (invisibly)
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DBISource-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-DBISource-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DBISource$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{DBISource$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DBISource$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/pkg-r/man/DataFrameSource.Rd
+++ b/pkg-r/man/DataFrameSource.Rd
@@ -39,76 +39,76 @@ df_sqlite$cleanup()
 \dontshow{\}) # examplesIf}
 }
 \section{Super classes}{
-\code{\link[querychat:DataSource]{querychat::DataSource}} -> \code{\link[querychat:DBISource]{querychat::DBISource}} -> \code{DataFrameSource}
+\code{\link[querychat:DataSource]{DataSource}} -> \code{\link[querychat:DBISource]{DBISource}} -> \code{DataFrameSource}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-DataFrameSource-new}{\code{DataFrameSource$new()}}
-\item \href{#method-DataFrameSource-clone}{\code{DataFrameSource$clone()}}
+  \itemize{
+    \item \href{#method-DataFrameSource-initialize}{\code{DataFrameSource$new()}}
+    \item \href{#method-DataFrameSource-clone}{\code{DataFrameSource$clone()}}
+  }
 }
-}
-\if{html}{\out{
-<details><summary>Inherited methods</summary>
+\if{html}{\out{<details><summary>Inherited methods</summary>
 <ul>
-<li><span class="pkg-link" data-pkg="querychat" data-topic="DBISource" data-id="cleanup"><a href='../../querychat/html/DBISource.html#method-DBISource-cleanup'><code>querychat::DBISource$cleanup()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="querychat" data-topic="DBISource" data-id="execute_query"><a href='../../querychat/html/DBISource.html#method-DBISource-execute_query'><code>querychat::DBISource$execute_query()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="querychat" data-topic="DBISource" data-id="get_data"><a href='../../querychat/html/DBISource.html#method-DBISource-get_data'><code>querychat::DBISource$get_data()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="querychat" data-topic="DBISource" data-id="get_db_type"><a href='../../querychat/html/DBISource.html#method-DBISource-get_db_type'><code>querychat::DBISource$get_db_type()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="querychat" data-topic="DBISource" data-id="get_schema"><a href='../../querychat/html/DBISource.html#method-DBISource-get_schema'><code>querychat::DBISource$get_schema()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="querychat" data-topic="DBISource" data-id="get_semantic_views_description"><a href='../../querychat/html/DBISource.html#method-DBISource-get_semantic_views_description'><code>querychat::DBISource$get_semantic_views_description()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="querychat" data-topic="DBISource" data-id="test_query"><a href='../../querychat/html/DBISource.html#method-DBISource-test_query'><code>querychat::DBISource$test_query()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="querychat" data-topic="DBISource" data-id="cleanup"><a href='../../querychat/html/DBISource.html#method-DBISource-cleanup'><code>DBISource$cleanup()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="querychat" data-topic="DBISource" data-id="execute_query"><a href='../../querychat/html/DBISource.html#method-DBISource-execute_query'><code>DBISource$execute_query()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="querychat" data-topic="DBISource" data-id="get_data"><a href='../../querychat/html/DBISource.html#method-DBISource-get_data'><code>DBISource$get_data()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="querychat" data-topic="DBISource" data-id="get_db_type"><a href='../../querychat/html/DBISource.html#method-DBISource-get_db_type'><code>DBISource$get_db_type()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="querychat" data-topic="DBISource" data-id="get_schema"><a href='../../querychat/html/DBISource.html#method-DBISource-get_schema'><code>DBISource$get_schema()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="querychat" data-topic="DBISource" data-id="get_semantic_views_description"><a href='../../querychat/html/DBISource.html#method-DBISource-get_semantic_views_description'><code>DBISource$get_semantic_views_description()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="querychat" data-topic="DBISource" data-id="test_query"><a href='../../querychat/html/DBISource.html#method-DBISource-test_query'><code>DBISource$test_query()</code></a></span></li>
 </ul>
-</details>
-}}
+</details>}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-DataFrameSource-new"></a>}}
-\if{latex}{\out{\hypertarget{method-DataFrameSource-new}{}}}
-\subsection{Method \code{new()}}{
-Create a new DataFrameSource
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DataFrameSource$new(
+\if{html}{\out{<a id="method-DataFrameSource-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-DataFrameSource-initialize}{}}}
+\subsection{\code{DataFrameSource$new()}}{
+  Create a new DataFrameSource
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DataFrameSource$new(
   df,
   table_name,
   engine = getOption("querychat.DataFrameSource.engine", NULL)
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{df}}{A data frame.}
-
-\item{\code{table_name}}{Name to use for the table in SQL queries. Must be a
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{df}}{A data frame.}
+      \item{\code{table_name}}{Name to use for the table in SQL queries. Must be a
 valid table name (start with letter, contain only letters, numbers,
 and underscores)}
-
-\item{\code{engine}}{Database engine to use: "duckdb" or "sqlite". Set the
+      \item{\code{engine}}{Database engine to use: "duckdb" or "sqlite". Set the
 global option \code{querychat.DataFrameSource.engine} to specify the default
 engine for all instances. If NULL (default), uses the first available
 engine from duckdb or RSQLite (in that order).}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A new DataFrameSource object
+  }
 }
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A new DataFrameSource object
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DataFrameSource-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-DataFrameSource-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DataFrameSource$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{DataFrameSource$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DataFrameSource$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/pkg-r/man/DataSource.Rd
+++ b/pkg-r/man/DataSource.Rd
@@ -23,143 +23,156 @@ MyDataSource <- R6::R6Class(
 
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{table_name}}{Name of the table to be used in SQL queries}
-}
-\if{html}{\out{</div>}}
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{table_name}}{Name of the table to be used in SQL queries}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-DataSource-get_db_type}{\code{DataSource$get_db_type()}}
-\item \href{#method-DataSource-get_schema}{\code{DataSource$get_schema()}}
-\item \href{#method-DataSource-execute_query}{\code{DataSource$execute_query()}}
-\item \href{#method-DataSource-test_query}{\code{DataSource$test_query()}}
-\item \href{#method-DataSource-get_data}{\code{DataSource$get_data()}}
-\item \href{#method-DataSource-cleanup}{\code{DataSource$cleanup()}}
-\item \href{#method-DataSource-clone}{\code{DataSource$clone()}}
-}
+  \itemize{
+    \item \href{#method-DataSource-get_db_type}{\code{DataSource$get_db_type()}}
+    \item \href{#method-DataSource-get_schema}{\code{DataSource$get_schema()}}
+    \item \href{#method-DataSource-execute_query}{\code{DataSource$execute_query()}}
+    \item \href{#method-DataSource-test_query}{\code{DataSource$test_query()}}
+    \item \href{#method-DataSource-get_data}{\code{DataSource$get_data()}}
+    \item \href{#method-DataSource-cleanup}{\code{DataSource$cleanup()}}
+    \item \href{#method-DataSource-clone}{\code{DataSource$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DataSource-get_db_type"></a>}}
 \if{latex}{\out{\hypertarget{method-DataSource-get_db_type}{}}}
-\subsection{Method \code{get_db_type()}}{
-Get the database type
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DataSource$get_db_type()}\if{html}{\out{</div>}}
+\subsection{\code{DataSource$get_db_type()}}{
+  Get the database type
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DataSource$get_db_type()}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A string describing the database type (e.g., "DuckDB", "SQLite")
+  }
 }
 
-\subsection{Returns}{
-A string describing the database type (e.g., "DuckDB", "SQLite")
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DataSource-get_schema"></a>}}
 \if{latex}{\out{\hypertarget{method-DataSource-get_schema}{}}}
-\subsection{Method \code{get_schema()}}{
-Get schema information about the table
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DataSource$get_schema(categorical_threshold = 20)}\if{html}{\out{</div>}}
+\subsection{\code{DataSource$get_schema()}}{
+  Get schema information about the table
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DataSource$get_schema(categorical_threshold = 20)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{categorical_threshold}}{Maximum number of unique values for a text
+column to be considered categorical}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A string containing schema information formatted for LLM prompts
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{categorical_threshold}}{Maximum number of unique values for a text
-column to be considered categorical}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A string containing schema information formatted for LLM prompts
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DataSource-execute_query"></a>}}
 \if{latex}{\out{\hypertarget{method-DataSource-execute_query}{}}}
-\subsection{Method \code{execute_query()}}{
-Execute a SQL query and return results
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DataSource$execute_query(query)}\if{html}{\out{</div>}}
+\subsection{\code{DataSource$execute_query()}}{
+  Execute a SQL query and return results
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DataSource$execute_query(query)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{query}}{SQL query string to execute}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A data frame containing query results
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{query}}{SQL query string to execute}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A data frame containing query results
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DataSource-test_query"></a>}}
 \if{latex}{\out{\hypertarget{method-DataSource-test_query}{}}}
-\subsection{Method \code{test_query()}}{
-Test a SQL query by fetching only one row
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DataSource$test_query(query, require_all_columns = FALSE)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{query}}{SQL query string to test}
-
-\item{\code{require_all_columns}}{If \code{TRUE}, validates that the result includes
+\subsection{\code{DataSource$test_query()}}{
+  Test a SQL query by fetching only one row
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DataSource$test_query(query, require_all_columns = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{query}}{SQL query string to test}
+      \item{\code{require_all_columns}}{If \code{TRUE}, validates that the result includes
 all original table columns (default: \code{FALSE})}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A data frame containing one row of results (or empty if no
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A data frame containing one row of results (or empty if no
 matches)
+  }
 }
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DataSource-get_data"></a>}}
 \if{latex}{\out{\hypertarget{method-DataSource-get_data}{}}}
-\subsection{Method \code{get_data()}}{
-Get the unfiltered data as a data frame
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DataSource$get_data()}\if{html}{\out{</div>}}
+\subsection{\code{DataSource$get_data()}}{
+  Get the unfiltered data as a data frame
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DataSource$get_data()}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A data frame containing all data from the table
+  }
 }
 
-\subsection{Returns}{
-A data frame containing all data from the table
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DataSource-cleanup"></a>}}
 \if{latex}{\out{\hypertarget{method-DataSource-cleanup}{}}}
-\subsection{Method \code{cleanup()}}{
-Clean up resources (close connections, etc.)
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DataSource$cleanup()}\if{html}{\out{</div>}}
+\subsection{\code{DataSource$cleanup()}}{
+  Clean up resources (close connections, etc.)
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DataSource$cleanup()}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    NULL (invisibly)
+  }
 }
 
-\subsection{Returns}{
-NULL (invisibly)
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-DataSource-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-DataSource-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DataSource$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{DataSource$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{DataSource$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/pkg-r/man/QueryChat.Rd
+++ b/pkg-r/man/QueryChat.Rd
@@ -94,49 +94,50 @@ qc <- QueryChat$new(con, "mtcars")
 \dontshow{\}) # examplesIf}
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{greeting}}{The greeting message displayed to users.}
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{greeting}}{The greeting message displayed to users.}
 
-\item{\code{id}}{ID for the QueryChat instance.}
+    \item{\code{id}}{ID for the QueryChat instance.}
 
-\item{\code{tools}}{The allowed tools for the chat client.}
-}
-\if{html}{\out{</div>}}
+    \item{\code{tools}}{The allowed tools for the chat client.}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Active bindings}{
-\if{html}{\out{<div class="r6-active-bindings">}}
-\describe{
-\item{\code{system_prompt}}{Get the system prompt.}
+  \if{html}{\out{<div class="r6-active-bindings">}}
+  \describe{
+    \item{\code{system_prompt}}{Get the system prompt.}
 
-\item{\code{data_source}}{Get or set the current data source. When setting,
+    \item{\code{data_source}}{Get or set the current data source. When setting,
 the value is normalized and the system prompt is rebuilt.}
-}
-\if{html}{\out{</div>}}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-QueryChat-new}{\code{QueryChat$new()}}
-\item \href{#method-QueryChat-client}{\code{QueryChat$client()}}
-\item \href{#method-QueryChat-console}{\code{QueryChat$console()}}
-\item \href{#method-QueryChat-app}{\code{QueryChat$app()}}
-\item \href{#method-QueryChat-app_obj}{\code{QueryChat$app_obj()}}
-\item \href{#method-QueryChat-sidebar}{\code{QueryChat$sidebar()}}
-\item \href{#method-QueryChat-ui}{\code{QueryChat$ui()}}
-\item \href{#method-QueryChat-server}{\code{QueryChat$server()}}
-\item \href{#method-QueryChat-generate_greeting}{\code{QueryChat$generate_greeting()}}
-\item \href{#method-QueryChat-cleanup}{\code{QueryChat$cleanup()}}
-\item \href{#method-QueryChat-clone}{\code{QueryChat$clone()}}
-}
+  \itemize{
+    \item \href{#method-QueryChat-initialize}{\code{QueryChat$new()}}
+    \item \href{#method-QueryChat-client}{\code{QueryChat$client()}}
+    \item \href{#method-QueryChat-console}{\code{QueryChat$console()}}
+    \item \href{#method-QueryChat-app}{\code{QueryChat$app()}}
+    \item \href{#method-QueryChat-app_obj}{\code{QueryChat$app_obj()}}
+    \item \href{#method-QueryChat-sidebar}{\code{QueryChat$sidebar()}}
+    \item \href{#method-QueryChat-ui}{\code{QueryChat$ui()}}
+    \item \href{#method-QueryChat-server}{\code{QueryChat$server()}}
+    \item \href{#method-QueryChat-generate_greeting}{\code{QueryChat$generate_greeting()}}
+    \item \href{#method-QueryChat-cleanup}{\code{QueryChat$cleanup()}}
+    \item \href{#method-QueryChat-clone}{\code{QueryChat$clone()}}
+  }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-QueryChat-new"></a>}}
-\if{latex}{\out{\hypertarget{method-QueryChat-new}{}}}
-\subsection{Method \code{new()}}{
-Create a new QueryChat object.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{QueryChat$new(
+\if{html}{\out{<a id="method-QueryChat-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-QueryChat-initialize}{}}}
+\subsection{\code{QueryChat$new()}}{
+  Create a new QueryChat object.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{QueryChat$new(
   data_source,
   table_name = missing_arg(),
   ...,
@@ -149,140 +150,130 @@ Create a new QueryChat object.
   extra_instructions = NULL,
   prompt_template = NULL,
   cleanup = NA
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{data_source}}{Either a data.frame, a database connection (e.g., DBI
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{data_source}}{Either a data.frame, a database connection (e.g., DBI
 connection), or \code{NULL} to defer setting the data source until later.
 When \code{NULL}, the data source must be set via the \verb{$data_source} property
 or passed to \verb{$server()} before calling methods that require data access.}
-
-\item{\code{table_name}}{A string specifying the table name to use in SQL
+      \item{\code{table_name}}{A string specifying the table name to use in SQL
 queries. If \code{data_source} is a data.frame, this is the name to refer to
 it by in queries (typically the variable name). If not provided, will
 be inferred from the variable name for data.frame inputs. For database
 connections or \code{NULL} data sources, this parameter is required.}
-
-\item{\code{...}}{Additional arguments (currently unused).}
-
-\item{\code{id}}{Optional module ID for the QueryChat instance. If not provided,
+      \item{\code{...}}{Additional arguments (currently unused).}
+      \item{\code{id}}{Optional module ID for the QueryChat instance. If not provided,
 will be auto-generated from \code{table_name}. The ID is used to namespace
 the Shiny module.}
-
-\item{\code{greeting}}{Optional initial message to display to users. Can be a
+      \item{\code{greeting}}{Optional initial message to display to users. Can be a
 character string (in Markdown format) or a file path. If not provided,
 a greeting will be generated at the start of each conversation using
 the LLM, which adds latency and cost. Use \verb{$generate_greeting()} to
 create a greeting to save and reuse.}
-
-\item{\code{client}}{Optional chat client. Can be:
+      \item{\code{client}}{Optional chat client. Can be:
 \itemize{
 \item An \link[ellmer:Chat]{ellmer::Chat} object
-\item A string to pass to \code{\link[ellmer:chat-any]{ellmer::chat()}} (e.g., \code{"openai/gpt-4o"})
+\item A string to pass to \code{\link[ellmer:chat]{ellmer::chat()}} (e.g., \code{"openai/gpt-4o"})
 \item \code{NULL} (default): Uses the \code{querychat.client} option, the
 \code{QUERYCHAT_CLIENT} environment variable, or defaults to
 \code{\link[ellmer:chat_openai]{ellmer::chat_openai()}}
 }}
-
-\item{\code{tools}}{Which querychat tools to include in the chat client, by
+      \item{\code{tools}}{Which querychat tools to include in the chat client, by
 default. \code{"update"} includes the tools for updating and resetting the
 dashboard and \code{"query"} includes the tool for executing SQL queries.
 Use \code{tools = "update"} when you only want the dashboard updating tools,
 or when you want to disable the querying tool entirely to prevent the
 LLM from seeing any of the data in your dataset.}
-
-\item{\code{data_description}}{Optional description of the data in plain text or
+      \item{\code{data_description}}{Optional description of the data in plain text or
 Markdown. Can be a string or a file path. This provides context to the
 LLM about what the data represents.}
-
-\item{\code{categorical_threshold}}{For text columns, the maximum number of
+      \item{\code{categorical_threshold}}{For text columns, the maximum number of
 unique values to consider as a categorical variable. Default is 20.}
-
-\item{\code{extra_instructions}}{Optional additional instructions for the chat
+      \item{\code{extra_instructions}}{Optional additional instructions for the chat
 model in plain text or Markdown. Can be a string or a file path.}
-
-\item{\code{prompt_template}}{Optional path to or string of a custom prompt
+      \item{\code{prompt_template}}{Optional path to or string of a custom prompt
 template file. If not provided, the default querychat template will be
 used. See the package prompts directory for the default template
 format.}
-
-\item{\code{cleanup}}{Whether or not to automatically run \verb{$cleanup()} when the
+      \item{\code{cleanup}}{Whether or not to automatically run \verb{$cleanup()} when the
 Shiny session/app stops. By default, cleanup only occurs if \code{QueryChat}
 gets created within a Shiny session. Set to \code{TRUE} to always clean up,
 or \code{FALSE} to never clean up automatically.}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A new \code{QueryChat} object.
+  }
 }
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A new \code{QueryChat} object.
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-QueryChat-client"></a>}}
 \if{latex}{\out{\hypertarget{method-QueryChat-client}{}}}
-\subsection{Method \code{client()}}{
-Create a chat client, complete with registered tools, for the current
+\subsection{\code{QueryChat$client()}}{
+  Create a chat client, complete with registered tools, for the current
 data source.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{QueryChat$client(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{QueryChat$client(
   tools = NA,
   update_dashboard = function(query, title) {
  },
   reset_dashboard = function() {
  }
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{tools}}{Which querychat tools to include in the chat client.
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{tools}}{Which querychat tools to include in the chat client.
 \code{"update"} includes the tools for updating and resetting the dashboard
 and \code{"query"} includes the tool for executing SQL queries. By default,
 when \code{tools = NA}, the values provided at initialization are used.}
-
-\item{\code{update_dashboard}}{Optional function to call with the \code{query} and
+      \item{\code{update_dashboard}}{Optional function to call with the \code{query} and
 \code{title} generated by the LLM for the \code{update_dashboard} tool.}
-
-\item{\code{reset_dashboard}}{Optional function to call when the
+      \item{\code{reset_dashboard}}{Optional function to call when the
 \code{reset_dashboard} tool is called.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-QueryChat-console"></a>}}
 \if{latex}{\out{\hypertarget{method-QueryChat-console}{}}}
-\subsection{Method \code{console()}}{
-Launch a console-based chat interface with the data source.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{QueryChat$console(new = FALSE, ..., tools = "query")}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{new}}{Whether to create a new chat client instance or continue the
+\subsection{\code{QueryChat$console()}}{
+  Launch a console-based chat interface with the data source.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{QueryChat$console(new = FALSE, ..., tools = "query")}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{new}}{Whether to create a new chat client instance or continue the
 conversation from the last console chat session (the default).}
-
-\item{\code{...}}{Additional arguments passed to the \verb{$client()} method.}
-
-\item{\code{tools}}{Which querychat tools to include in the chat client. See
+      \item{\code{...}}{Additional arguments passed to the \verb{$client()} method.}
+      \item{\code{tools}}{Which querychat tools to include in the chat client. See
 \verb{$client()} for details. Ignored when not creating a new chat client.
 By default, only the \code{"query"} tool is included, regardless of the
 \code{tools} set at initialization.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
-\if{html}{\out{</div>}}
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-QueryChat-app"></a>}}
 \if{latex}{\out{\hypertarget{method-QueryChat-app}{}}}
-\subsection{Method \code{app()}}{
-Create and run a Shiny gadget for chatting with data
+\subsection{\code{QueryChat$app()}}{
+  Create and run a Shiny gadget for chatting with data
 
 Runs a Shiny gadget (designed for interactive use) that provides a
 complete interface for chatting with your data using natural language. If
@@ -294,36 +285,37 @@ you're looking to deploy this app or run it through some other means, see
 qc <- QueryChat$new(mtcars)
 qc$app()
 }\if{html}{\out{</div>}}
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{QueryChat$app(..., bookmark_store = "url")}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{...}}{Arguments passed to \verb{$app_obj()}.}
-
-\item{\code{bookmark_store}}{The bookmarking storage method. Passed to
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{QueryChat$app(..., bookmark_store = "url")}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{...}}{Arguments passed to \verb{$app_obj()}.}
+      \item{\code{bookmark_store}}{The bookmarking storage method. Passed to
 \code{\link[shiny:enableBookmarking]{shiny::enableBookmarking()}}. If \code{"url"} or \code{"server"}, the chat state
 (including current query) will be bookmarked. Default is \code{"url"}.}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-Invisibly returns a list of session-specific values:
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Invisibly returns a list of session-specific values:
 \itemize{
 \item \code{df}: The final filtered data frame
 \item \code{sql}: The final SQL query string
 \item \code{title}: The final title
 \item \code{client}: The session-specific chat client instance
 }
+  }
 }
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-QueryChat-app_obj"></a>}}
 \if{latex}{\out{\hypertarget{method-QueryChat-app_obj}{}}}
-\subsection{Method \code{app_obj()}}{
-A streamlined Shiny app for chatting with data
+\subsection{\code{QueryChat$app_obj()}}{
+  A streamlined Shiny app for chatting with data
 
 Creates a Shiny app designed for chatting with data, with:
 \itemize{
@@ -339,30 +331,31 @@ qc <- QueryChat$new(mtcars)
 app <- qc$app_obj()
 shiny::runApp(app)
 }\if{html}{\out{</div>}}
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{QueryChat$app_obj(..., bookmark_store = "url")}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{...}}{Additional arguments (currently unused).}
-
-\item{\code{bookmark_store}}{The bookmarking storage method. Passed to
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{QueryChat$app_obj(..., bookmark_store = "url")}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{...}}{Additional arguments (currently unused).}
+      \item{\code{bookmark_store}}{The bookmarking storage method. Passed to
 \code{\link[shiny:enableBookmarking]{shiny::enableBookmarking()}}. If \code{"url"} or \code{"server"}, the chat state
 (including current query) will be bookmarked. Default is \code{"url"}.}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A Shiny app object that can be run with \code{shiny::runApp()}.
+  }
 }
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A Shiny app object that can be run with \code{shiny::runApp()}.
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-QueryChat-sidebar"></a>}}
 \if{latex}{\out{\hypertarget{method-QueryChat-sidebar}{}}}
-\subsection{Method \code{sidebar()}}{
-Create a sidebar containing the querychat UI.
+\subsection{\code{QueryChat$sidebar()}}{
+  Create a sidebar containing the querychat UI.
 
 This method generates a \code{\link[bslib:sidebar]{bslib::sidebar()}} component containing the chat
 interface, suitable for use with \code{\link[bslib:page_sidebar]{bslib::page_sidebar()}} or similar
@@ -375,44 +368,42 @@ ui <- page_sidebar(
   # Main content here
 )
 }\if{html}{\out{</div>}}
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{QueryChat$sidebar(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{QueryChat$sidebar(
   ...,
   width = 400,
   height = "100\%",
   fillable = TRUE,
   id = NULL
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{...}}{Additional arguments passed to \code{\link[bslib:sidebar]{bslib::sidebar()}}.}
-
-\item{\code{width}}{Width of the sidebar in pixels. Default is 400.}
-
-\item{\code{height}}{Height of the sidebar. Default is "100\%".}
-
-\item{\code{fillable}}{Whether the sidebar should be fillable. Default is
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{...}}{Additional arguments passed to \code{\link[bslib:sidebar]{bslib::sidebar()}}.}
+      \item{\code{width}}{Width of the sidebar in pixels. Default is 400.}
+      \item{\code{height}}{Height of the sidebar. Default is "100\%".}
+      \item{\code{fillable}}{Whether the sidebar should be fillable. Default is
 \code{TRUE}.}
-
-\item{\code{id}}{Optional ID for the QueryChat instance. If not provided, will
+      \item{\code{id}}{Optional ID for the QueryChat instance. If not provided, will
 use the ID provided at initialization. If using \verb{$sidebar()} in a Shiny
 module, you'll need to provide \code{id = ns("your_id")} where \code{ns} is the
 namespacing function from \code{\link[shiny:NS]{shiny::NS()}}.}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A \code{\link[bslib:sidebar]{bslib::sidebar()}} UI component.
+  }
 }
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A \code{\link[bslib:sidebar]{bslib::sidebar()}} UI component.
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-QueryChat-ui"></a>}}
 \if{latex}{\out{\hypertarget{method-QueryChat-ui}{}}}
-\subsection{Method \code{ui()}}{
-Create the UI for the querychat chat interface.
+\subsection{\code{QueryChat$ui()}}{
+  Create the UI for the querychat chat interface.
 
 This method generates the chat UI component. Typically you'll use
 \verb{$sidebar()} instead, which wraps this in a sidebar layout.
@@ -423,31 +414,32 @@ ui <- fluidPage(
   qc$ui()
 )
 }\if{html}{\out{</div>}}
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{QueryChat$ui(..., id = NULL)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{...}}{Additional arguments passed to \code{\link[shinychat:chat_ui]{shinychat::chat_ui()}}.}
-
-\item{\code{id}}{Optional ID for the QueryChat instance. If not provided,
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{QueryChat$ui(..., id = NULL)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{...}}{Additional arguments passed to \code{\link[shinychat:chat_ui]{shinychat::chat_ui()}}.}
+      \item{\code{id}}{Optional ID for the QueryChat instance. If not provided,
 will use the ID provided at initialization. If using \verb{$ui()} in a Shiny
 module, you'll need to provide \code{id = ns("your_id")} where \code{ns} is the
 namespacing function from \code{\link[shiny:NS]{shiny::NS()}}.}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A UI component containing the chat interface.
+  }
 }
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A UI component containing the chat interface.
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-QueryChat-server"></a>}}
 \if{latex}{\out{\hypertarget{method-QueryChat-server}{}}}
-\subsection{Method \code{server()}}{
-Initialize the querychat server logic.
+\subsection{\code{QueryChat$server()}}{
+  Initialize the querychat server logic.
 
 This method must be called within a Shiny server function. It sets up the
 reactive logic for the chat interface and returns session-specific
@@ -463,52 +455,48 @@ server <- function(input, output, session) \{
   output$title <- renderText(qc_vals$title() \%||\% "No Query")
 \}
 }\if{html}{\out{</div>}}
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{QueryChat$server(
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{QueryChat$server(
   data_source = NULL,
   client = NULL,
   enable_bookmarking = FALSE,
   ...,
   id = NULL,
   session = shiny::getDefaultReactiveDomain()
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{data_source}}{Optional data source to use. If provided, sets the
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{data_source}}{Optional data source to use. If provided, sets the
 data_source property before initializing server logic. This is useful
 for the deferred pattern where data_source is not known at
 initialization time (e.g., when the data source depends on session-
 specific authentication).}
-
-\item{\code{client}}{Optional chat client override for this session. Can be an
+      \item{\code{client}}{Optional chat client override for this session. Can be an
 \link[ellmer:Chat]{ellmer::Chat} object or a string (e.g., \code{"openai/gpt-4o"}). If provided,
 overrides the client set at initialization for this session only —
 other sessions are unaffected. This is useful when the client must be
 created within a session scope (e.g., Posit Connect managed credentials).}
-
-\item{\code{enable_bookmarking}}{Whether to enable bookmarking for the chat
+      \item{\code{enable_bookmarking}}{Whether to enable bookmarking for the chat
 state. Default is \code{FALSE}. When enabled, the chat state (including
 current query, title, and chat history) will be saved and restored
 with Shiny bookmarks. This requires that the Shiny app has bookmarking
 enabled via \code{shiny::enableBookmarking()} or the \code{enableBookmarking}
 parameter of \code{shiny::shinyApp()}.}
-
-\item{\code{...}}{Ignored.}
-
-\item{\code{id}}{Optional module ID for the QueryChat instance. If not provided,
+      \item{\code{...}}{Ignored.}
+      \item{\code{id}}{Optional module ID for the QueryChat instance. If not provided,
 will use the ID provided at initialization. When used in Shiny modules,
 this \code{id} should match the \code{id} used in the corresponding UI function
 (i.e., \code{qc$ui(id = ns("your_id"))} pairs with \code{qc$server(id = "your_id")}).}
-
-\item{\code{session}}{The Shiny session object.}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A list containing session-specific reactive values and the chat
+      \item{\code{session}}{The Shiny session object.}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A list containing session-specific reactive values and the chat
 client with the following elements:
 \itemize{
 \item \code{df}: Reactive expression returning the current filtered data frame
@@ -516,13 +504,14 @@ client with the following elements:
 \item \code{title}: Reactive value for the current title
 \item \code{client}: The session-specific chat client instance
 }
+  }
 }
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-QueryChat-generate_greeting"></a>}}
 \if{latex}{\out{\hypertarget{method-QueryChat-generate_greeting}{}}}
-\subsection{Method \code{generate_greeting()}}{
-Generate a welcome greeting for the chat.
+\subsection{\code{QueryChat$generate_greeting()}}{
+  Generate a welcome greeting for the chat.
 
 By default, \code{QueryChat$new()} generates a greeting at the start of every
 new conversation, which is convenient for getting started and
@@ -539,27 +528,29 @@ writeLines(greeting, "mtcars_greeting.md")
 # Later, use the saved greeting
 qc2 <- QueryChat$new(mtcars, greeting = "mtcars_greeting.md")
 }\if{html}{\out{</div>}}
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{QueryChat$generate_greeting(echo = c("none", "output"))}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{QueryChat$generate_greeting(echo = c("none", "output"))}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{echo}}{Whether to print the greeting to the console. Options are
+\code{"none"} (default, no output) or \code{"output"} (print to console).}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    The greeting string in Markdown format.
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{echo}}{Whether to print the greeting to the console. Options are
-\code{"none"} (default, no output) or \code{"output"} (print to console).}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-The greeting string in Markdown format.
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-QueryChat-cleanup"></a>}}
 \if{latex}{\out{\hypertarget{method-QueryChat-cleanup}{}}}
-\subsection{Method \code{cleanup()}}{
-Clean up resources associated with the data source.
+\subsection{\code{QueryChat$cleanup()}}{
+  Clean up resources associated with the data source.
 
 This method releases any resources (e.g., database connections)
 associated with the data source. Call this when you are done using the
@@ -567,29 +558,33 @@ QueryChat object to avoid resource leaks.
 
 Note: If \code{auto_cleanup} was set to \code{TRUE} in the constructor, this will
 be called automatically when the Shiny app stops.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{QueryChat$cleanup()}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{QueryChat$cleanup()}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Invisibly returns \code{NULL}. Resources are cleaned up internally.
+  }
 }
 
-\subsection{Returns}{
-Invisibly returns \code{NULL}. Resources are cleaned up internally.
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-QueryChat-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-QueryChat-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{QueryChat$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{QueryChat$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{QueryChat$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/pkg-r/man/TblSqlSource.Rd
+++ b/pkg-r/man/TblSqlSource.Rd
@@ -31,197 +31,211 @@ mtcars_source$cleanup()
 \dontshow{\}) # examplesIf}
 }
 \section{Super classes}{
-\code{\link[querychat:DataSource]{querychat::DataSource}} -> \code{\link[querychat:DBISource]{querychat::DBISource}} -> \code{TblSqlSource}
+\code{\link[querychat:DataSource]{DataSource}} -> \code{\link[querychat:DBISource]{DBISource}} -> \code{TblSqlSource}
 }
 \section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{table_name}}{Name of the table to be used in SQL queries}
-}
-\if{html}{\out{</div>}}
+  \if{html}{\out{<div class="r6-fields">}}
+  \describe{
+    \item{\code{table_name}}{Name of the table to be used in SQL queries}
+  }
+  \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-TblSqlSource-new}{\code{TblSqlSource$new()}}
-\item \href{#method-TblSqlSource-get_db_type}{\code{TblSqlSource$get_db_type()}}
-\item \href{#method-TblSqlSource-get_schema}{\code{TblSqlSource$get_schema()}}
-\item \href{#method-TblSqlSource-execute_query}{\code{TblSqlSource$execute_query()}}
-\item \href{#method-TblSqlSource-test_query}{\code{TblSqlSource$test_query()}}
-\item \href{#method-TblSqlSource-prep_query}{\code{TblSqlSource$prep_query()}}
-\item \href{#method-TblSqlSource-get_data}{\code{TblSqlSource$get_data()}}
-\item \href{#method-TblSqlSource-cleanup}{\code{TblSqlSource$cleanup()}}
-\item \href{#method-TblSqlSource-clone}{\code{TblSqlSource$clone()}}
+  \itemize{
+    \item \href{#method-TblSqlSource-initialize}{\code{TblSqlSource$new()}}
+    \item \href{#method-TblSqlSource-get_db_type}{\code{TblSqlSource$get_db_type()}}
+    \item \href{#method-TblSqlSource-get_schema}{\code{TblSqlSource$get_schema()}}
+    \item \href{#method-TblSqlSource-execute_query}{\code{TblSqlSource$execute_query()}}
+    \item \href{#method-TblSqlSource-test_query}{\code{TblSqlSource$test_query()}}
+    \item \href{#method-TblSqlSource-prep_query}{\code{TblSqlSource$prep_query()}}
+    \item \href{#method-TblSqlSource-get_data}{\code{TblSqlSource$get_data()}}
+    \item \href{#method-TblSqlSource-cleanup}{\code{TblSqlSource$cleanup()}}
+    \item \href{#method-TblSqlSource-clone}{\code{TblSqlSource$clone()}}
+  }
 }
-}
-\if{html}{\out{
-<details open><summary>Inherited methods</summary>
+\if{html}{\out{<details open><summary>Inherited methods</summary>
 <ul>
-<li><span class="pkg-link" data-pkg="querychat" data-topic="DBISource" data-id="get_semantic_views_description"><a href='../../querychat/html/DBISource.html#method-DBISource-get_semantic_views_description'><code>querychat::DBISource$get_semantic_views_description()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="querychat" data-topic="DBISource" data-id="get_semantic_views_description"><a href='../../querychat/html/DBISource.html#method-DBISource-get_semantic_views_description'><code>DBISource$get_semantic_views_description()</code></a></span></li>
 </ul>
-</details>
-}}
+</details>}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-TblSqlSource-new"></a>}}
-\if{latex}{\out{\hypertarget{method-TblSqlSource-new}{}}}
-\subsection{Method \code{new()}}{
-Create a new TblSqlSource
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TblSqlSource$new(tbl, table_name = missing_arg())}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{tbl}}{A \code{\link[dbplyr:tbl_sql]{dbplyr::tbl_sql()}} (or SQL tibble via \code{\link[dplyr:tbl]{dplyr::tbl()}}).}
-
-\item{\code{table_name}}{Name of the table in the database. Can be a character
+\if{html}{\out{<a id="method-TblSqlSource-initialize"></a>}}
+\if{latex}{\out{\hypertarget{method-TblSqlSource-initialize}{}}}
+\subsection{\code{TblSqlSource$new()}}{
+  Create a new TblSqlSource
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{TblSqlSource$new(tbl, table_name = missing_arg())}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{tbl}}{A \code{\link[dbplyr:tbl_sql]{dbplyr::tbl_sql()}} (or SQL tibble via \code{\link[dplyr:tbl]{dplyr::tbl()}}).}
+      \item{\code{table_name}}{Name of the table in the database. Can be a character
 string, or will be inferred from the \code{tbl} argument, if possible.}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A new TblSqlSource object
+  }
 }
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A new TblSqlSource object
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TblSqlSource-get_db_type"></a>}}
 \if{latex}{\out{\hypertarget{method-TblSqlSource-get_db_type}{}}}
-\subsection{Method \code{get_db_type()}}{
-Get the database type
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TblSqlSource$get_db_type()}\if{html}{\out{</div>}}
+\subsection{\code{TblSqlSource$get_db_type()}}{
+  Get the database type
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{TblSqlSource$get_db_type()}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A string describing the database type (e.g., "DuckDB", "SQLite")
+  }
 }
 
-\subsection{Returns}{
-A string describing the database type (e.g., "DuckDB", "SQLite")
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TblSqlSource-get_schema"></a>}}
 \if{latex}{\out{\hypertarget{method-TblSqlSource-get_schema}{}}}
-\subsection{Method \code{get_schema()}}{
-Get schema information about the table
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TblSqlSource$get_schema(categorical_threshold = 20)}\if{html}{\out{</div>}}
+\subsection{\code{TblSqlSource$get_schema()}}{
+  Get schema information about the table
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{TblSqlSource$get_schema(categorical_threshold = 20)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{categorical_threshold}}{Maximum number of unique values for a text
+column to be considered categorical}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A string containing schema information formatted for LLM prompts
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{categorical_threshold}}{Maximum number of unique values for a text
-column to be considered categorical}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A string containing schema information formatted for LLM prompts
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TblSqlSource-execute_query"></a>}}
 \if{latex}{\out{\hypertarget{method-TblSqlSource-execute_query}{}}}
-\subsection{Method \code{execute_query()}}{
-Execute a SQL query and return results
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TblSqlSource$execute_query(query)}\if{html}{\out{</div>}}
+\subsection{\code{TblSqlSource$execute_query()}}{
+  Execute a SQL query and return results
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{TblSqlSource$execute_query(query)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{query}}{SQL query string to execute}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A data frame containing query results
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{query}}{SQL query string to execute}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A data frame containing query results
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TblSqlSource-test_query"></a>}}
 \if{latex}{\out{\hypertarget{method-TblSqlSource-test_query}{}}}
-\subsection{Method \code{test_query()}}{
-Test a SQL query by fetching only one row
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TblSqlSource$test_query(query, require_all_columns = FALSE)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{query}}{SQL query string to test}
-
-\item{\code{require_all_columns}}{If \code{TRUE}, validates that the result includes
+\subsection{\code{TblSqlSource$test_query()}}{
+  Test a SQL query by fetching only one row
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{TblSqlSource$test_query(query, require_all_columns = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{query}}{SQL query string to test}
+      \item{\code{require_all_columns}}{If \code{TRUE}, validates that the result includes
 all original table columns (default: \code{FALSE})}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A data frame containing one row of results (or empty if no matches)
+  }
 }
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A data frame containing one row of results (or empty if no matches)
-}
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TblSqlSource-prep_query"></a>}}
 \if{latex}{\out{\hypertarget{method-TblSqlSource-prep_query}{}}}
-\subsection{Method \code{prep_query()}}{
-Prepare a generic \verb{SELECT * FROM ____} query to work with the SQL tibble
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TblSqlSource$prep_query(query)}\if{html}{\out{</div>}}
+\subsection{\code{TblSqlSource$prep_query()}}{
+  Prepare a generic \verb{SELECT * FROM ____} query to work with the SQL tibble
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{TblSqlSource$prep_query(query)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{query}}{SQL query as a string}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A complete SQL query string
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{query}}{SQL query as a string}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-A complete SQL query string
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TblSqlSource-get_data"></a>}}
 \if{latex}{\out{\hypertarget{method-TblSqlSource-get_data}{}}}
-\subsection{Method \code{get_data()}}{
-Get the unfiltered data as a SQL tibble
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TblSqlSource$get_data()}\if{html}{\out{</div>}}
+\subsection{\code{TblSqlSource$get_data()}}{
+  Get the unfiltered data as a SQL tibble
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{TblSqlSource$get_data()}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A \code{\link[dbplyr:tbl_sql]{dbplyr::tbl_sql()}} containing the original, unfiltered data
+  }
 }
 
-\subsection{Returns}{
-A \code{\link[dbplyr:tbl_sql]{dbplyr::tbl_sql()}} containing the original, unfiltered data
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TblSqlSource-cleanup"></a>}}
 \if{latex}{\out{\hypertarget{method-TblSqlSource-cleanup}{}}}
-\subsection{Method \code{cleanup()}}{
-Clean up resources (close connections, etc.)
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TblSqlSource$cleanup()}\if{html}{\out{</div>}}
+\subsection{\code{TblSqlSource$cleanup()}}{
+  Clean up resources (close connections, etc.)
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{TblSqlSource$cleanup()}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    NULL (invisibly)
+  }
 }
 
-\subsection{Returns}{
-NULL (invisibly)
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TblSqlSource-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-TblSqlSource-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TblSqlSource$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{TblSqlSource$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{TblSqlSource$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/pkg-r/man/querychat-convenience.Rd
+++ b/pkg-r/man/querychat-convenience.Rd
@@ -61,7 +61,7 @@ a greeting to save and reuse.}
 \item{client}{Optional chat client. Can be:
 \itemize{
 \item An \link[ellmer:Chat]{ellmer::Chat} object
-\item A string to pass to \code{\link[ellmer:chat-any]{ellmer::chat()}} (e.g., \code{"openai/gpt-4o"})
+\item A string to pass to \code{\link[ellmer:chat]{ellmer::chat()}} (e.g., \code{"openai/gpt-4o"})
 \item \code{NULL} (default): Uses the \code{querychat.client} option, the
 \code{QUERYCHAT_CLIENT} environment variable, or defaults to
 \code{\link[ellmer:chat_openai]{ellmer::chat_openai()}}

--- a/pkg-r/man/querychat-package.Rd
+++ b/pkg-r/man/querychat-package.Rd
@@ -85,6 +85,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Garrick Aden-Buie \email{garrick@posit.co} (\href{https://orcid.org/0000-0002-7111-0077}{ORCID})
   \item Joe Cheng \email{joe@posit.co} [conceptor]
   \item Carson Sievert \email{carson@posit.co} (\href{https://orcid.org/0000-0002-4958-2844}{ORCID})
 }

--- a/pkg-r/vignettes/greet.Rmd
+++ b/pkg-r/vignettes/greet.Rmd
@@ -35,15 +35,15 @@ qc$app()  # Launch the app
 You can provide suggestions to the user by using the `<span class="suggestion"> </span>` tag:
 
 ```markdown
-* **Filter and sort the data:**
-  * <span class="suggestion">Show only Adelie penguins</span>
-  * <span class="suggestion">Filter to penguins with body mass over 4000g</span>
-  * <span class="suggestion">Sort by flipper length from longest to shortest</span>
+##### Filter and sort the data
+* <span class="suggestion">Show only Adelie penguins</span>
+* <span class="suggestion">Filter to penguins with body mass over 4000g</span>
+* <span class="suggestion">Sort by flipper length from longest to shortest</span>
 
-* **Answer questions about the data:**
-  * <span class="suggestion">What is the average bill length by species?</span>
-  * <span class="suggestion">How many penguins are in each island?</span>
-  * <span class="suggestion">Which species has the largest average body mass?</span>
+##### Answer questions about the data
+* <span class="suggestion">What is the average bill length by species?</span>
+* <span class="suggestion">How many penguins are in each island?</span>
+* <span class="suggestion">Which species has the largest average body mass?</span>
 ```
 
 These suggestions appear in the greeting and automatically populate the chat text box when clicked.


### PR DESCRIPTION
## Summary

ShinyChat recently added auto-promotion of suggestion links into styled cards, but it doesn't support nested lists yet (posit-dev/shinychat#220). Our prompts, examples, and docs all taught/used nested lists for grouping suggestions — meaning none of those suggestions would get promoted to cards.

This replaces nested lists with `#####` headings above flat lists everywhere:

- **System prompts** (R + Python): syntax example changed from "Nested lists" to "Grouped suggestions", added explicit "never use nested lists" guideline
- **`GREETING_PROMPT`** (R + Python): changed from "two-level bulleted list" to "grouped under headings"
- **Example greetings**: `pkg-py/examples/greeting.md`, R example apps (`02-sidebar-app`, `03-module-app`, `sqlite`)
- **Documentation**: `pkg-r/vignettes/greet.Rmd`, `pkg-py/docs/greet.qmd`
