### PR TITLE
fix: use HTML list tags in suggestion prompts to ensure card rendering

### DIFF
--- a/pkg-py/examples/greeting.md
+++ b/pkg-py/examples/greeting.md
@@ -1,21 +1,15 @@
 Hello! Welcome to your Titanic data dashboard. I'm here to help you filter, sort, and analyze the data. Here are a few ideas to get you started:
 
 ##### Explore the data
-<ul>
-<li><span class="suggestion">Show me all passengers who survived</span></li>
-<li><span class="suggestion">Show only first class passengers</span></li>
-</ul>
+* <span class="suggestion">Show me all passengers who survived</span>
+* <span class="suggestion">Show only first class passengers</span>
 
 ##### Analyze statistics
-<ul>
-<li><span class="suggestion">What is the average age of passengers?</span></li>
-<li><span class="suggestion">How many children were on board?</span></li>
-</ul>
+* <span class="suggestion">What is the average age of passengers?</span>
+* <span class="suggestion">How many children were on board?</span>
 
 ##### Compare and dig deeper
-<ul>
-<li><span class="suggestion">Which class had the highest survival rate?</span></li>
-<li><span class="suggestion">Show the fare distribution by embarkation town</span></li>
-</ul>
+* <span class="suggestion">Which class had the highest survival rate?</span>
+* <span class="suggestion">Show the fare distribution by embarkation town</span>
 
 Let me know what you'd like to explore!

--- a/pkg-py/examples/greeting.md
+++ b/pkg-py/examples/greeting.md
@@ -1,15 +1,21 @@
 Hello! Welcome to your Titanic data dashboard. I'm here to help you filter, sort, and analyze the data. Here are a few ideas to get you started:
 
 ##### Explore the data
-* <span class="suggestion">Show me all passengers who survived</span>
-* <span class="suggestion">Show only first class passengers</span>
+<ul>
+<li><span class="suggestion">Show me all passengers who survived</span></li>
+<li><span class="suggestion">Show only first class passengers</span></li>
+</ul>
 
 ##### Analyze statistics
-* <span class="suggestion">What is the average age of passengers?</span>
-* <span class="suggestion">How many children were on board?</span>
+<ul>
+<li><span class="suggestion">What is the average age of passengers?</span></li>
+<li><span class="suggestion">How many children were on board?</span></li>
+</ul>
 
 ##### Compare and dig deeper
-* <span class="suggestion">Which class had the highest survival rate?</span>
-* <span class="suggestion">Show the fare distribution by embarkation town</span>
+<ul>
+<li><span class="suggestion">Which class had the highest survival rate?</span></li>
+<li><span class="suggestion">Show the fare distribution by embarkation town</span></li>
+</ul>
 
 Let me know what you'd like to explore!

--- a/pkg-py/src/querychat/_querychat_core.py
+++ b/pkg-py/src/querychat/_querychat_core.py
@@ -25,7 +25,8 @@ from .tools import UpdateDashboardData
 
 GREETING_PROMPT: str = (
     "Please give me a friendly greeting. "
-    "Include a few sample prompts grouped under headings."
+    "Include a few sample suggestions grouped under ##### headings, "
+    "using the suggestion card format from your instructions."
 )
 """Prompt used to generate the initial greeting message."""
 

--- a/pkg-py/src/querychat/prompts/prompt.md
+++ b/pkg-py/src/querychat/prompts/prompt.md
@@ -212,7 +212,7 @@ You cannot query or analyze the data. If users ask questions about data values, 
 
 #### Suggestion Syntax
 
-Use `<span class="suggestion">` tags to create clickable prompt buttons in the UI. The text inside should be a complete, actionable prompt that users can click to continue the conversation.
+Use `<span class="suggestion">` tags to create clickable suggestion buttons in the UI. The text inside should be a complete, actionable suggestion that users can click to continue the conversation.
 
 #### Syntax Examples
 

--- a/pkg-py/src/querychat/prompts/prompt.md
+++ b/pkg-py/src/querychat/prompts/prompt.md
@@ -210,69 +210,76 @@ You cannot query or analyze the data. If users ask questions about data values, 
 {{/has_tool_query}}
 ### Providing Suggestions for Next Steps
 
-#### Suggestion Syntax
+#### How Suggestions Work
 
-Use `<span class="suggestion">` tags to create clickable prompt buttons in the UI. The text inside should be a complete, actionable prompt that users can click to continue the conversation.
+Wrap suggestion text in `<span class="suggestion">` tags. When the UI sees a markdown list where **every item contains only a single suggestion span and nothing else**, it renders the list as a grid of interactive cards. Any extra text inside a list item breaks card rendering.
 
-#### Syntax Examples
+#### Card Format (default — use this for all suggestion lists)
 
-**List format (most common):**
-```md
-* <span class="suggestion">Show me examples of …</span>
-* <span class="suggestion">What are the key differences between …</span>
-* <span class="suggestion">Explain how …</span>
+Suggestion lists render as a grid of interactive cards. Use a `<ul>` tag containing `<li>` items, each with a single `<span class="suggestion">` and no other text:
+
+```
+<ul>
+<li><span class="suggestion">Show me examples of …</span></li>
+<li><span class="suggestion">What are the key differences between …</span></li>
+<li><span class="suggestion">Explain how …</span></li>
+</ul>
 ```
 
-**Inline in prose:**
-```md
-You might want to <span class="suggestion">explore the advanced features</span> or <span class="suggestion">show me a practical example</span>.
-```
+Use `#####` headings to group suggestions by theme:
 
-**Grouped suggestions:**
-```md
+```
 {{#has_tool_query}}
 ##### Analyze the data
-* <span class="suggestion">What's the average …?</span>
-* <span class="suggestion">How many …?</span>
+<ul>
+<li><span class="suggestion">What's the average …?</span></li>
+<li><span class="suggestion">How many …?</span></li>
+</ul>
 
 {{/has_tool_query}}
 {{#has_tool_visualize}}
 ##### Visualize the data
-* <span class="suggestion">Show a bar chart of …</span>
-* <span class="suggestion">Plot the trend of … over time</span>
+<ul>
+<li><span class="suggestion">Show a bar chart of …</span></li>
+<li><span class="suggestion">Plot the trend of … over time</span></li>
+</ul>
 
 {{/has_tool_visualize}}
 ##### Filter and sort
-* <span class="suggestion">Show records from the year …</span>
-* <span class="suggestion">Sort the ____ by ____ …</span>
+<ul>
+<li><span class="suggestion">Show records from the year …</span></li>
+<li><span class="suggestion">Sort the ____ by ____ …</span></li>
+</ul>
+```
+
+WRONG — extra text inside the `<li>` prevents card rendering:
+```
+<li>Try this: <span class="suggestion">…</span></li>
+```
+
+#### Inline Format (rare — only within a prose sentence)
+
+Inline suggestions render as clickable text links, not cards. Only use this when embedding a suggestion naturally within a sentence:
+
+```md
+You might want to <span class="suggestion">explore the advanced features</span> or <span class="suggestion">see a practical example</span>.
 ```
 
 #### When to Include Suggestions
 
-**Always provide suggestions:**
-- At the start of a conversation
-- When beginning a new line of exploration
-- After completing a topic (to suggest new directions)
+**Always:** at the start of a conversation, when beginning a new topic, or after completing a topic.
 
-**Use best judgment for:**
-- Mid-conversation responses (include when they add clear value)
-- Follow-up answers (include if multiple paths forward exist)
+**Use judgment:** mid-conversation when multiple paths forward exist.
 
-**Avoid when:**
-- The user has asked a very specific question requiring only a direct answer
-- The conversation is clearly wrapping up
+**Avoid:** for very specific questions needing only a direct answer.
 
-#### Suggestion Guidelines
+#### Guidelines
 
-- Suggestions can appear **anywhere** in your response—not just at the end
-- Use list format at the end for 2-4 follow-up options (most common pattern)
-- Never use nested lists for suggestions — group them under headings instead
-- Use inline suggestions within prose when contextually appropriate
-- Write suggestions as complete, natural prompts (not fragments)
+- Write suggestions as complete, natural sentences (not fragments)
 - Only suggest actions you can perform with your tools and capabilities
-- Never duplicate the suggestion text in your response
-- Never use generic phrases like "If you'd like to..." or "Would you like to explore..." — instead, provide concrete suggestions
-- Never refer to suggestions as "prompts" – call them "suggestions" or "ideas" or similar
+- Never duplicate the suggestion text elsewhere in your response
+- Never use generic lead-ins like "If you'd like to..." — just provide the suggestion list
+- Never refer to suggestions as "prompts" — call them "suggestions" or "ideas"
 
 ## Important Guidelines
 

--- a/pkg-py/src/querychat/prompts/prompt.md
+++ b/pkg-py/src/querychat/prompts/prompt.md
@@ -210,13 +210,15 @@ You cannot query or analyze the data. If users ask questions about data values, 
 {{/has_tool_query}}
 ### Providing Suggestions for Next Steps
 
-#### How Suggestions Work
+#### Suggestion Syntax
 
-Wrap suggestion text in `<span class="suggestion">` tags. When the UI sees a `<ul>` where **every `<li>` contains only a single suggestion span and nothing else**, it renders the list as a grid of interactive cards. Any extra text inside a `<li>` breaks card rendering. Always use explicit HTML `<ul>`/`<li>` tags instead of markdown list markers (`*`, `-`) — markdown lists work in principle, but missing the space after the marker (e.g., `-<span>` instead of `- <span>`) silently breaks the list parse.
+Use `<span class="suggestion">` tags to create clickable suggestion buttons in the UI. The text inside should be a complete, actionable prompt that users can click to continue the conversation.
 
-#### Card Format (default — use this for all suggestion lists)
+#### Suggestion Cards
 
-Suggestion lists render as a grid of interactive cards. Use a `<ul>` tag containing `<li>` items, each with a single `<span class="suggestion">` and no other text:
+When the UI sees a `<ul>` where **every `<li>` contains only a single suggestion span and nothing else**, it renders the list as a grid of interactive cards. Any extra text inside a `<li>` breaks card rendering. Always use explicit HTML `<ul>`/`<li>` tags instead of markdown list markers (`*`, `-`) — markdown lists work in principle, but missing the space after the marker (e.g., `-<span>` instead of `- <span>`) silently breaks the list parse.
+
+Use a `<ul>` tag containing `<li>` items, each with a single `<span class="suggestion">` and no other text:
 
 ```
 <ul>

--- a/pkg-py/src/querychat/prompts/prompt.md
+++ b/pkg-py/src/querychat/prompts/prompt.md
@@ -212,7 +212,7 @@ You cannot query or analyze the data. If users ask questions about data values, 
 
 #### How Suggestions Work
 
-Wrap suggestion text in `<span class="suggestion">` tags. When the UI sees a markdown list where **every item contains only a single suggestion span and nothing else**, it renders the list as a grid of interactive cards. Any extra text inside a list item breaks card rendering.
+Wrap suggestion text in `<span class="suggestion">` tags. When the UI sees a `<ul>` where **every `<li>` contains only a single suggestion span and nothing else**, it renders the list as a grid of interactive cards. Any extra text inside a `<li>` breaks card rendering. Always use explicit HTML `<ul>`/`<li>` tags instead of markdown list markers (`*`, `-`) — markdown lists work in principle, but missing the space after the marker (e.g., `-<span>` instead of `- <span>`) silently breaks the list parse.
 
 #### Card Format (default — use this for all suggestion lists)
 
@@ -255,6 +255,12 @@ Use `#####` headings to group suggestions by theme:
 WRONG — extra text inside the `<li>` prevents card rendering:
 ```
 <li>Try this: <span class="suggestion">…</span></li>
+```
+
+WRONG — markdown list markers are fragile; omitting the space breaks the list parse entirely:
+```
+-<span class="suggestion">…</span>
+*<span class="suggestion">…</span>
 ```
 
 #### Inline Format (rare — only within a prose sentence)

--- a/pkg-py/src/querychat/prompts/prompt.md
+++ b/pkg-py/src/querychat/prompts/prompt.md
@@ -212,14 +212,11 @@ You cannot query or analyze the data. If users ask questions about data values, 
 
 #### Suggestion Syntax
 
-Use `<span class="suggestion">` tags to create clickable suggestion buttons in the UI. The text inside should be a complete, actionable prompt that users can click to continue the conversation.
+Use `<span class="suggestion">` tags to create clickable prompt buttons in the UI. The text inside should be a complete, actionable prompt that users can click to continue the conversation.
 
-#### Suggestion Cards
+#### Syntax Examples
 
-When the UI sees a `<ul>` where **every `<li>` contains only a single suggestion span and nothing else**, it renders the list as a grid of interactive cards. Any extra text inside a `<li>` breaks card rendering. Always use explicit HTML `<ul>`/`<li>` tags instead of markdown list markers (`*`, `-`) — markdown lists work in principle, but missing the space after the marker (e.g., `-<span>` instead of `- <span>`) silently breaks the list parse.
-
-Use a `<ul>` tag containing `<li>` items, each with a single `<span class="suggestion">` and no other text:
-
+**List format (most common):**
 ```
 <ul>
 <li><span class="suggestion">Show me examples of …</span></li>
@@ -228,8 +225,9 @@ Use a `<ul>` tag containing `<li>` items, each with a single `<span class="sugge
 </ul>
 ```
 
-Use `#####` headings to group suggestions by theme:
+Use explicit HTML `<ul>`/`<li>` tags instead of markdown list markers (`*`, `-`). Markdown lists work when formatted correctly, but omitting the space after the marker (e.g., `-<span>` instead of `- <span>`) silently breaks the list parse, so HTML tags are more reliable.
 
+**Grouped suggestions:**
 ```
 {{#has_tool_query}}
 ##### Analyze the data
@@ -254,40 +252,38 @@ Use `#####` headings to group suggestions by theme:
 </ul>
 ```
 
-WRONG — extra text inside the `<li>` prevents card rendering:
-```
-<li>Try this: <span class="suggestion">…</span></li>
-```
-
-WRONG — markdown list markers are fragile; omitting the space breaks the list parse entirely:
-```
--<span class="suggestion">…</span>
-*<span class="suggestion">…</span>
-```
-
-#### Inline Format (rare — only within a prose sentence)
-
-Inline suggestions render as clickable text links, not cards. Only use this when embedding a suggestion naturally within a sentence:
-
+**Inline in prose (secondary format):**
+Inline suggestions render as clickable text links within a sentence, not as cards.
 ```md
-You might want to <span class="suggestion">explore the advanced features</span> or <span class="suggestion">see a practical example</span>.
+You might want to <span class="suggestion">explore the advanced features</span> or <span class="suggestion">show me a practical example</span>.
 ```
 
 #### When to Include Suggestions
 
-**Always:** at the start of a conversation, when beginning a new topic, or after completing a topic.
+**Always provide suggestions:**
+- At the start of a conversation
+- When beginning a new line of exploration
+- After completing a topic (to suggest new directions)
 
-**Use judgment:** mid-conversation when multiple paths forward exist.
+**Use best judgment for:**
+- Mid-conversation responses (include when they add clear value)
+- Follow-up answers (include if multiple paths forward exist)
 
-**Avoid:** for very specific questions needing only a direct answer.
+**Avoid when:**
+- The user has asked a very specific question requiring only a direct answer
+- The conversation is clearly wrapping up
 
-#### Guidelines
+#### Suggestion Guidelines
 
-- Write suggestions as complete, natural sentences (not fragments)
+- Suggestions can appear **anywhere** in your response—not just at the end
+- Use list format at the end for 2-4 follow-up options (most common pattern)
+- Never use nested lists for suggestions — group them under headings instead
+- Use inline suggestions within prose when contextually appropriate
+- Write suggestions as complete, natural prompts (not fragments)
 - Only suggest actions you can perform with your tools and capabilities
-- Never duplicate the suggestion text elsewhere in your response
-- Never use generic lead-ins like "If you'd like to..." — just provide the suggestion list
-- Never refer to suggestions as "prompts" — call them "suggestions" or "ideas"
+- Never duplicate the suggestion text in your response
+- Never use generic phrases like "If you'd like to..." or "Would you like to explore..." — instead, provide concrete suggestions
+- Never refer to suggestions as "prompts" – call them "suggestions" or "ideas" or similar
 
 ## Important Guidelines
 

--- a/pkg-r/DESCRIPTION
+++ b/pkg-r/DESCRIPTION
@@ -51,8 +51,8 @@ Suggests:
     withr
 VignetteBuilder:
     knitr
+Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-Config/roxygen2/version: 8.0.0

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -146,4 +146,8 @@ mod_server <- function(
 }
 
 # TODO: Make this dependent on enabled tools
-GREETING_PROMPT <- "Please give me a friendly greeting. Include a few sample prompts grouped under headings."
+GREETING_PROMPT <- paste(
+  "Please give me a friendly greeting.",
+  "Include a few sample suggestions grouped under ##### headings,",
+  "using the suggestion card format from your instructions."
+)

--- a/pkg-r/inst/prompts/prompt.md
+++ b/pkg-r/inst/prompts/prompt.md
@@ -128,7 +128,7 @@ You cannot query or analyze the data. If users ask questions about data values, 
 
 #### Suggestion Syntax
 
-Use `<span class="suggestion">` tags to create clickable prompt buttons in the UI. The text inside should be a complete, actionable prompt that users can click to continue the conversation.
+Use `<span class="suggestion">` tags to create clickable suggestion buttons in the UI. The text inside should be a complete, actionable suggestion that users can click to continue the conversation.
 
 #### Syntax Examples
 

--- a/pkg-r/inst/prompts/prompt.md
+++ b/pkg-r/inst/prompts/prompt.md
@@ -126,13 +126,15 @@ You cannot query or analyze the data. If users ask questions about data values, 
 {{/has_tool_query}}
 ### Providing Suggestions for Next Steps
 
-#### How Suggestions Work
+#### Suggestion Syntax
 
-Wrap suggestion text in `<span class="suggestion">` tags. When the UI sees a `<ul>` where **every `<li>` contains only a single suggestion span and nothing else**, it renders the list as a grid of interactive cards. Any extra text inside a `<li>` breaks card rendering. Always use explicit HTML `<ul>`/`<li>` tags instead of markdown list markers (`*`, `-`) — markdown lists work in principle, but missing the space after the marker (e.g., `-<span>` instead of `- <span>`) silently breaks the list parse.
+Use `<span class="suggestion">` tags to create clickable suggestion buttons in the UI. The text inside should be a complete, actionable prompt that users can click to continue the conversation.
 
-#### Card Format (default — use this for all suggestion lists)
+#### Suggestion Cards
 
-Suggestion lists render as a grid of interactive cards. Use a `<ul>` tag containing `<li>` items, each with a single `<span class="suggestion">` and no other text:
+When the UI sees a `<ul>` where **every `<li>` contains only a single suggestion span and nothing else**, it renders the list as a grid of interactive cards. Any extra text inside a `<li>` breaks card rendering. Always use explicit HTML `<ul>`/`<li>` tags instead of markdown list markers (`*`, `-`) — markdown lists work in principle, but missing the space after the marker (e.g., `-<span>` instead of `- <span>`) silently breaks the list parse.
+
+Use a `<ul>` tag containing `<li>` items, each with a single `<span class="suggestion">` and no other text:
 
 ```
 <ul>

--- a/pkg-r/inst/prompts/prompt.md
+++ b/pkg-r/inst/prompts/prompt.md
@@ -128,7 +128,7 @@ You cannot query or analyze the data. If users ask questions about data values, 
 
 #### How Suggestions Work
 
-Wrap suggestion text in `<span class="suggestion">` tags. When the UI sees a markdown list where **every item contains only a single suggestion span and nothing else**, it renders the list as a grid of interactive cards. Any extra text inside a list item breaks card rendering.
+Wrap suggestion text in `<span class="suggestion">` tags. When the UI sees a `<ul>` where **every `<li>` contains only a single suggestion span and nothing else**, it renders the list as a grid of interactive cards. Any extra text inside a `<li>` breaks card rendering. Always use explicit HTML `<ul>`/`<li>` tags instead of markdown list markers (`*`, `-`) — markdown lists work in principle, but missing the space after the marker (e.g., `-<span>` instead of `- <span>`) silently breaks the list parse.
 
 #### Card Format (default — use this for all suggestion lists)
 
@@ -161,6 +161,12 @@ Use `#####` headings to group suggestions by theme:
 WRONG — extra text inside the `<li>` prevents card rendering:
 ```
 <li>Try this: <span class="suggestion">…</span></li>
+```
+
+WRONG — markdown list markers are fragile; omitting the space breaks the list parse entirely:
+```
+-<span class="suggestion">…</span>
+*<span class="suggestion">…</span>
 ```
 
 #### Inline Format (rare — only within a prose sentence)

--- a/pkg-r/inst/prompts/prompt.md
+++ b/pkg-r/inst/prompts/prompt.md
@@ -126,61 +126,66 @@ You cannot query or analyze the data. If users ask questions about data values, 
 {{/has_tool_query}}
 ### Providing Suggestions for Next Steps
 
-#### Suggestion Syntax
+#### How Suggestions Work
 
-Use `<span class="suggestion">` tags to create clickable prompt buttons in the UI. The text inside should be a complete, actionable prompt that users can click to continue the conversation.
+Wrap suggestion text in `<span class="suggestion">` tags. When the UI sees a markdown list where **every item contains only a single suggestion span and nothing else**, it renders the list as a grid of interactive cards. Any extra text inside a list item breaks card rendering.
 
-#### Syntax Examples
+#### Card Format (default — use this for all suggestion lists)
 
-**List format (most common):**
-```md
-* <span class="suggestion">Show me examples of …</span>
-* <span class="suggestion">What are the key differences between …</span>
-* <span class="suggestion">Explain how …</span>
+Suggestion lists render as a grid of interactive cards. Use a `<ul>` tag containing `<li>` items, each with a single `<span class="suggestion">` and no other text:
+
+```
+<ul>
+<li><span class="suggestion">Show me examples of …</span></li>
+<li><span class="suggestion">What are the key differences between …</span></li>
+<li><span class="suggestion">Explain how …</span></li>
+</ul>
 ```
 
-**Inline in prose:**
-```md
-You might want to <span class="suggestion">explore the advanced features</span> or <span class="suggestion">show me a practical example</span>.
-```
+Use `#####` headings to group suggestions by theme:
 
-**Grouped suggestions:**
-```md
+```
 ##### Analyze the data
-* <span class="suggestion">What's the average …?</span>
-* <span class="suggestion">How many …?</span>
+<ul>
+<li><span class="suggestion">What's the average …?</span></li>
+<li><span class="suggestion">How many …?</span></li>
+</ul>
 
 ##### Filter and sort
-* <span class="suggestion">Show records from the year …</span>
-* <span class="suggestion">Sort the ____ by ____ …</span>
+<ul>
+<li><span class="suggestion">Show records from the year …</span></li>
+<li><span class="suggestion">Sort the ____ by ____ …</span></li>
+</ul>
+```
+
+WRONG — extra text inside the `<li>` prevents card rendering:
+```
+<li>Try this: <span class="suggestion">…</span></li>
+```
+
+#### Inline Format (rare — only within a prose sentence)
+
+Inline suggestions render as clickable text links, not cards. Only use this when embedding a suggestion naturally within a sentence:
+
+```md
+You might want to <span class="suggestion">explore the advanced features</span> or <span class="suggestion">see a practical example</span>.
 ```
 
 #### When to Include Suggestions
 
-**Always provide suggestions:**
-- At the start of a conversation
-- When beginning a new line of exploration
-- After completing a topic (to suggest new directions)
+**Always:** at the start of a conversation, when beginning a new topic, or after completing a topic.
 
-**Use best judgment for:**
-- Mid-conversation responses (include when they add clear value)
-- Follow-up answers (include if multiple paths forward exist)
+**Use judgment:** mid-conversation when multiple paths forward exist.
 
-**Avoid when:**
-- The user has asked a very specific question requiring only a direct answer
-- The conversation is clearly wrapping up
+**Avoid:** for very specific questions needing only a direct answer.
 
-#### Suggestion Guidelines
+#### Guidelines
 
-- Suggestions can appear **anywhere** in your response—not just at the end
-- Use list format at the end for 2-4 follow-up options (most common pattern)
-- Never use nested lists for suggestions — group them under headings instead
-- Use inline suggestions within prose when contextually appropriate
-- Write suggestions as complete, natural prompts (not fragments)
+- Write suggestions as complete, natural sentences (not fragments)
 - Only suggest actions you can perform with your tools and capabilities
-- Never duplicate the suggestion text in your response
-- Never use generic phrases like "If you'd like to..." or "Would you like to explore..." — instead, provide concrete suggestions
-- Never refer to suggestions as "prompts" – call them "suggestions" or "ideas" or similar
+- Never duplicate the suggestion text elsewhere in your response
+- Never use generic lead-ins like "If you'd like to..." — just provide the suggestion list
+- Never refer to suggestions as "prompts" — call them "suggestions" or "ideas"
 
 ## Important Guidelines
 

--- a/pkg-r/inst/prompts/prompt.md
+++ b/pkg-r/inst/prompts/prompt.md
@@ -128,14 +128,11 @@ You cannot query or analyze the data. If users ask questions about data values, 
 
 #### Suggestion Syntax
 
-Use `<span class="suggestion">` tags to create clickable suggestion buttons in the UI. The text inside should be a complete, actionable prompt that users can click to continue the conversation.
+Use `<span class="suggestion">` tags to create clickable prompt buttons in the UI. The text inside should be a complete, actionable prompt that users can click to continue the conversation.
 
-#### Suggestion Cards
+#### Syntax Examples
 
-When the UI sees a `<ul>` where **every `<li>` contains only a single suggestion span and nothing else**, it renders the list as a grid of interactive cards. Any extra text inside a `<li>` breaks card rendering. Always use explicit HTML `<ul>`/`<li>` tags instead of markdown list markers (`*`, `-`) — markdown lists work in principle, but missing the space after the marker (e.g., `-<span>` instead of `- <span>`) silently breaks the list parse.
-
-Use a `<ul>` tag containing `<li>` items, each with a single `<span class="suggestion">` and no other text:
-
+**List format (most common):**
 ```
 <ul>
 <li><span class="suggestion">Show me examples of …</span></li>
@@ -144,8 +141,9 @@ Use a `<ul>` tag containing `<li>` items, each with a single `<span class="sugge
 </ul>
 ```
 
-Use `#####` headings to group suggestions by theme:
+Use explicit HTML `<ul>`/`<li>` tags instead of markdown list markers (`*`, `-`). Markdown lists work when formatted correctly, but omitting the space after the marker (e.g., `-<span>` instead of `- <span>`) silently breaks the list parse, so HTML tags are more reliable.
 
+**Grouped suggestions:**
 ```
 ##### Analyze the data
 <ul>
@@ -160,40 +158,38 @@ Use `#####` headings to group suggestions by theme:
 </ul>
 ```
 
-WRONG — extra text inside the `<li>` prevents card rendering:
-```
-<li>Try this: <span class="suggestion">…</span></li>
-```
-
-WRONG — markdown list markers are fragile; omitting the space breaks the list parse entirely:
-```
--<span class="suggestion">…</span>
-*<span class="suggestion">…</span>
-```
-
-#### Inline Format (rare — only within a prose sentence)
-
-Inline suggestions render as clickable text links, not cards. Only use this when embedding a suggestion naturally within a sentence:
-
+**Inline in prose (secondary format):**
+Inline suggestions render as clickable text links within a sentence, not as cards.
 ```md
-You might want to <span class="suggestion">explore the advanced features</span> or <span class="suggestion">see a practical example</span>.
+You might want to <span class="suggestion">explore the advanced features</span> or <span class="suggestion">show me a practical example</span>.
 ```
 
 #### When to Include Suggestions
 
-**Always:** at the start of a conversation, when beginning a new topic, or after completing a topic.
+**Always provide suggestions:**
+- At the start of a conversation
+- When beginning a new line of exploration
+- After completing a topic (to suggest new directions)
 
-**Use judgment:** mid-conversation when multiple paths forward exist.
+**Use best judgment for:**
+- Mid-conversation responses (include when they add clear value)
+- Follow-up answers (include if multiple paths forward exist)
 
-**Avoid:** for very specific questions needing only a direct answer.
+**Avoid when:**
+- The user has asked a very specific question requiring only a direct answer
+- The conversation is clearly wrapping up
 
-#### Guidelines
+#### Suggestion Guidelines
 
-- Write suggestions as complete, natural sentences (not fragments)
+- Suggestions can appear **anywhere** in your response—not just at the end
+- Use list format at the end for 2-4 follow-up options (most common pattern)
+- Never use nested lists for suggestions — group them under headings instead
+- Use inline suggestions within prose when contextually appropriate
+- Write suggestions as complete, natural prompts (not fragments)
 - Only suggest actions you can perform with your tools and capabilities
-- Never duplicate the suggestion text elsewhere in your response
-- Never use generic lead-ins like "If you'd like to..." — just provide the suggestion list
-- Never refer to suggestions as "prompts" — call them "suggestions" or "ideas"
+- Never duplicate the suggestion text in your response
+- Never use generic phrases like "If you'd like to..." or "Would you like to explore..." — instead, provide concrete suggestions
+- Never refer to suggestions as "prompts" – call them "suggestions" or "ideas" or similar
 
 ## Important Guidelines
 


### PR DESCRIPTION
## Problem

Shinychat renders suggestion lists as interactive card grids when it sees a `<ul>` where every `<li>` contains a single `<span class="suggestion">` element. The previous prompt instructed the LLM to use markdown list syntax for suggestions:

```md
- <span class="suggestion">How many passengers survived?</span>
```

But some LLMs have a tendency to omit the space between the list marker and the HTML tag, producing:

```
-<span class="suggestion">How many passengers survived?</span>
```

Without the space, the markdown parser treats this as a paragraph (`<p>-<span>...`) instead of a list item (`<ul><li><span>...`). Since there's no `<ul>`, shinychat's card promotion never runs, and suggestions render as flat inline text instead of cards.

This was confirmed by running a Playwright test against the viz example app with an LLM-generated greeting — the HTML showed `<p>-<span class="suggestion">` consistently across multiple runs, with both `*` and `-` markers, and even with explicit examples of the correct format in the prompt.

## Fix

Switch the prompt examples from markdown list syntax to explicit HTML `<ul><li>` tags:

```html
<ul>
<li><span class="suggestion">How many passengers survived?</span></li>
<li><span class="suggestion">What is the average fare by class?</span></li>
</ul>
```

This works because shinychat's markdown pipeline includes `rehypeRaw`, which parses raw HTML into proper HAST nodes. The card promotion plugin then finds the `<ul>` and promotes it to a card grid as expected. The HTML approach was tested across multiple LLM runs and produced cards every time.

The prompt was also restructured to:
- Lead with *why* the format matters (card rendering), not just the syntax
- Show a concrete "WRONG" example of what breaks promotion
- Demote inline suggestions to a rare/secondary pattern
- Replace "prompts" with "suggestions" in the `GREETING_PROMPT` (consistent with the system prompt guideline "never refer to suggestions as prompts")

Cross-framework note: Streamlit (`unsafe_allow_html=True`), Gradio (native HTML), and Dash (`dangerously_allow_html=True`) all preserve raw HTML, so `<ul><li>` renders correctly there too. Dash's `convert_suggestion_spans()` regex still matches `<span class="suggestion"` inside the `<li>`.
