### PR TITLE
fix(pkg-py): resolve pyright 1.1.410 false-positive errors in Dash files

### DIFF
--- a/pkg-py/src/querychat/_dash.py
+++ b/pkg-py/src/querychat/_dash.py
@@ -335,13 +335,14 @@ class QueryChat(QueryChatBase[IntoFrameT], StateDictAccessorMixin[IntoFrameT]):
 def app_layout(ids: IDs, table_name: str, chat_ui):
     """Build the layout for the complete app."""
     import dash_ag_grid as dag
-    from dash import dcc, html
     from dash_bootstrap_components._components import (  # pyright: ignore[reportPrivateImportUsage]
         Button,
         Col,
         Container,
         Row,
     )
+
+    from dash import dcc, html
 
     # SQL card with dynamic title and reset button
     sql_card = card_ui(

--- a/pkg-py/src/querychat/_dash.py
+++ b/pkg-py/src/querychat/_dash.py
@@ -335,9 +335,13 @@ class QueryChat(QueryChatBase[IntoFrameT], StateDictAccessorMixin[IntoFrameT]):
 def app_layout(ids: IDs, table_name: str, chat_ui):
     """Build the layout for the complete app."""
     import dash_ag_grid as dag
-    import dash_bootstrap_components as dbc
-
     from dash import dcc, html
+    from dash_bootstrap_components._components import (  # pyright: ignore[reportPrivateImportUsage]
+        Button,
+        Col,
+        Container,
+        Row,
+    )
 
     # SQL card with dynamic title and reset button
     sql_card = card_ui(
@@ -346,7 +350,7 @@ def app_layout(ids: IDs, table_name: str, chat_ui):
             className="querychat-sql-display",
         ),
         title_id=ids.sql_title,
-        action_button=dbc.Button(
+        action_button=Button(
             "Reset Query",
             id=ids.reset_button,
             color="danger",
@@ -382,7 +386,7 @@ def app_layout(ids: IDs, table_name: str, chat_ui):
             dcc.Download(id=ids.download_csv),  # pyright: ignore[reportPrivateImportUsage]
         ],
         title="Data view",
-        action_button=dbc.Button(
+        action_button=Button(
             "Export CSV",
             id=ids.export_button,
             color="secondary",
@@ -400,13 +404,13 @@ def app_layout(ids: IDs, table_name: str, chat_ui):
         body_class_name="d-flex flex-column p-0 flex-grow-1",
     )
 
-    return dbc.Container(
+    return Container(
         [
             html.H1(f"querychat with {table_name}"),
-            dbc.Row(
+            Row(
                 [
-                    dbc.Col(chat_card, width=4),
-                    dbc.Col(
+                    Col(chat_card, width=4),
+                    Col(
                         [sql_card, data_card],
                         width=8,
                         className="d-flex flex-column",

--- a/pkg-py/src/querychat/_dash_ui.py
+++ b/pkg-py/src/querychat/_dash_ui.py
@@ -59,9 +59,14 @@ def card_ui(
     body_class_name: str = "",
 ) -> Component:
     """Create a Bootstrap card with optional header and action button."""
-    import dash_bootstrap_components as dbc
-
     from dash import html
+    from dash_bootstrap_components._components import (  # pyright: ignore[reportPrivateImportUsage]
+        Card,
+        CardBody,
+        CardHeader,
+        Col,
+        Row,
+    )
 
     children = []
 
@@ -73,42 +78,46 @@ def card_ui(
         title_el = html.H4(title or "", **title_kwargs)
 
         if action_button:
-            header_content = dbc.Row(
+            header_content = Row(
                 [
-                    dbc.Col(title_el),
-                    dbc.Col(action_button, width="auto"),
+                    Col(title_el),
+                    Col(action_button, width="auto"),
                 ],
                 align="center",
             )
         else:
             header_content = title_el
 
-        children.append(dbc.CardHeader(header_content))
+        children.append(CardHeader(header_content))
 
-    children.append(dbc.CardBody(body, className=body_class_name or None))
+    children.append(CardBody(body, className=body_class_name or None))
 
-    return dbc.Card(children, className=class_name or None)
+    return Card(children, className=class_name or None)
 
 
 def chat_container_ui(ids: IDs) -> list[Component]:
     """Create the chat UI container (messages + input)."""
-    import dash_bootstrap_components as dbc
-
     from dash import html
+    from dash_bootstrap_components._components import (  # pyright: ignore[reportPrivateImportUsage]
+        Button,
+        Input,
+        InputGroup,
+        Spinner,
+    )
 
     return [
         html.Div(
             id=ids.chat_history,
             className="querychat-chat-history",
         ),
-        dbc.InputGroup(
+        InputGroup(
             [
-                dbc.Input(
+                Input(
                     id=ids.chat_input,
                     placeholder="Ask a question about your data...",
                     type="text",
                 ),
-                dbc.Button(
+                Button(
                     "Send",
                     id=ids.send_button,
                     color="primary",
@@ -116,7 +125,7 @@ def chat_container_ui(ids: IDs) -> list[Component]:
             ]
         ),
         html.Div(
-            dbc.Spinner(
+            Spinner(
                 size="sm",
                 color="primary",
                 spinner_class_name="ms-2",

--- a/pkg-py/src/querychat/_dash_ui.py
+++ b/pkg-py/src/querychat/_dash_ui.py
@@ -59,7 +59,6 @@ def card_ui(
     body_class_name: str = "",
 ) -> Component:
     """Create a Bootstrap card with optional header and action button."""
-    from dash import html
     from dash_bootstrap_components._components import (  # pyright: ignore[reportPrivateImportUsage]
         Card,
         CardBody,
@@ -67,6 +66,8 @@ def card_ui(
         Col,
         Row,
     )
+
+    from dash import html
 
     children = []
 
@@ -97,13 +98,14 @@ def card_ui(
 
 def chat_container_ui(ids: IDs) -> list[Component]:
     """Create the chat UI container (messages + input)."""
-    from dash import html
     from dash_bootstrap_components._components import (  # pyright: ignore[reportPrivateImportUsage]
         Button,
         Input,
         InputGroup,
         Spinner,
     )
+
+    from dash import html
 
     return [
         html.Div(


### PR DESCRIPTION
## Summary

- pyright 1.1.410 now resolves `dbc.Button`, `dbc.Row`, `dbc.Col`, etc. as **modules** rather than classes, because `dash-bootstrap-components` 2.0.x stores each component in its own same-named file (`Button.py`, `Row.py`, …)
- This caused all five `test (3.x)` CI jobs to fail on the `feat/artifact-feature` branch, blocking progress there
- Fix: import from `dash_bootstrap_components._components` directly, where each name is an explicit class-level re-export — consistent with the existing `# pyright: ignore[reportPrivateImportUsage]` pattern already in these files

## Test plan

- [ ] CI passes on this branch (all Python version matrix jobs)