### PR TITLE
Clarify query prompt guidance to reduce unnecessary expanded tool results

### DIFF
--- a/pkg-py/src/querychat/prompts/prompt.md
+++ b/pkg-py/src/querychat/prompts/prompt.md
@@ -107,6 +107,9 @@ When the user asks you a question about the data, e.g. "What is the average ____
 - Use the `querychat_query` tool to run SQL queries
 - Always use SQL for calculations (counting, averaging, etc.) - NEVER do manual calculations
 - Always present key findings in your response text — do not assume the user can see the tool result (it may be collapsed)
+- If you are unsure whether to set `collapsed`, omit it and use the tool default behavior
+- If you set `collapsed` explicitly, prefer `collapsed=true`; use `collapsed=false` only when the user explicitly asks to see the raw table immediately
+- If you use `collapsed=false`, avoid repeating the same table rows/values in your response text
 - If you cannot complete the request using SQL, politely decline and explain why
 
 **Question Example:**

--- a/pkg-py/src/querychat/prompts/prompt.md
+++ b/pkg-py/src/querychat/prompts/prompt.md
@@ -125,7 +125,7 @@ You can create visualizations using the `querychat_visualize` tool, which uses g
 
 #### Visualization best practices
 
-The database schema in this prompt includes column names, types, and summary statistics. {{#has_tool_query}}If that context isn't sufficient for a confident visualization — e.g., you're unsure about value distributions, need to check for NULLs, or want to gauge row counts before choosing a chart type — use the `querychat_query` tool to inspect the data before visualizing. Always pass `collapsed=True` for these preparatory queries so the chart remains the focal point of the response.{{/has_tool_query}}
+The database schema in this prompt includes column names, types, and summary statistics. {{#has_tool_query}}If that context isn't sufficient for a confident visualization — e.g., you're unsure about value distributions, need to check for NULLs, or want to gauge row counts before choosing a chart type — use the `querychat_query` tool to inspect the data before visualizing. Always pass `collapsed=true` for these preparatory queries so the chart remains the focal point of the response.{{/has_tool_query}}
 
 Follow the principles below to produce clear, interpretable charts.
 
@@ -191,7 +191,7 @@ Match the chart type to what the user is trying to understand:
 </ggsql-syntax-reference>
 {{#has_tool_query}}
 
-**Avoid redundant expanded results.** If you run a preparatory query before visualizing, or if both a table and chart would show the same data, always pass `collapsed=True` on the query so the user sees the chart prominently, not a duplicate table above it. The user can still expand the table if they want the exact values.
+**Avoid redundant expanded results.** If you run a preparatory query before visualizing, or if both a table and chart would show the same data, always pass `collapsed=true` on the query so the user sees the chart prominently, not a duplicate table above it. The user can still expand the table if they want the exact values.
 {{/has_tool_query}}
 {{/has_tool_visualize}}
 {{^has_tool_visualize}}

--- a/pkg-py/src/querychat/prompts/tool-query.md
+++ b/pkg-py/src/querychat/prompts/tool-query.md
@@ -30,7 +30,7 @@ Parameters
 query :
     A valid {{db_type}} SQL SELECT statement. Must follow the database schema provided in the system prompt. Use clear column aliases (e.g., 'AVG(price) AS avg_price') and include SQL comments for complex logic. Subqueries and CTEs are encouraged for readability.
 collapsed :
-    Optional. If you are unsure, omit this parameter and use the default behavior. If you provide it explicitly, prefer true. Set to false only when the user explicitly asks to see the raw table immediately.
+    Optional. If omitted, visibility follows the app-configured default behavior (typically collapsed). If you are unsure, omit this parameter. If you provide it explicitly, prefer true. Set to false only when the user explicitly asks to see the raw table immediately.
 _intent :
     A brief, user-friendly description of what this query calculates or retrieves.
 

--- a/pkg-py/src/querychat/prompts/tool-query.md
+++ b/pkg-py/src/querychat/prompts/tool-query.md
@@ -19,7 +19,10 @@ Always use SQL for counting, averaging, summing, and other calculations—NEVER 
 - Optimize for readability over efficiency—use clear column aliases and SQL comments to explain complex logic
 - Subqueries and CTEs are acceptable and encouraged for complex calculations
 - After receiving results, always present the key findings in your response text — the tool result starts collapsed by default, so don't assume the user has seen the raw data
-- When the result is a single value or small summary, state it directly in prose. When the result is a table that IS the answer, either use a Markdown table in your response or set `collapsed` to `false` — not both
+- If you are unsure whether to control visibility, omit `collapsed` and rely on the tool default behavior
+- If you set `collapsed` explicitly, prefer `collapsed=true`
+- Use `collapsed=false` only when the user explicitly wants the raw table visible immediately (for example, "show me the rows/table")
+- When using `collapsed=false`, avoid duplicating the same rows/values in both the tool result and your response text
 - Do not reproduce large result sets in your response — summarize the key takeaways instead
 
 Parameters
@@ -27,7 +30,7 @@ Parameters
 query :
     A valid {{db_type}} SQL SELECT statement. Must follow the database schema provided in the system prompt. Use clear column aliases (e.g., 'AVG(price) AS avg_price') and include SQL comments for complex logic. Subqueries and CTEs are encouraged for readability.
 collapsed :
-    Optional (default: true). The result card starts collapsed by default; the user can expand it to see the query and results. Set to false when the query result table is the primary answer to the user's question and should be immediately visible without expanding.
+    Optional. If you are unsure, omit this parameter and use the default behavior. If you provide it explicitly, prefer true. Set to false only when the user explicitly asks to see the raw table immediately.
 _intent :
     A brief, user-friendly description of what this query calculates or retrieves.
 


### PR DESCRIPTION
## Why this matters
Recent collapse-related guidance improved defaults, but models can still overuse `collapsed=false` and produce duplicate visible table content alongside prose. This PR tightens prompt instructions so the model is less likely to expand query results unless the user explicitly asks to see rows/table output immediately.

## What changed
- In query-answering guidance, added explicit direction to omit `collapsed` when uncertain.
- Added guidance that when `collapsed` is set explicitly, prefer `collapsed=true`.
- Restricted `collapsed=false` to explicit user intent to view raw table rows immediately.
- Added anti-duplication guidance when `collapsed=false` is used.

## Related
- Builds on and clarifies direction from #239.
