### PR TITLE
Adopt shinychat 0.4.0 greeting API with bookmark persistence

### DIFF
--- a/pkg-py/CHANGELOG.md
+++ b/pkg-py/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
+* Chat greetings now use shinychat's greeting API (requires shinychat >= 0.4.0). A provided `greeting` renders instantly when the app loads, and when no `greeting` is given one is generated on demand without being added to the conversation history. Generated greetings are now preserved across bookmark/restore. (#249)
 * The query tool result card now starts collapsed by default. Users can still expand it to see the SQL query and results. Set `QUERYCHAT_TOOL_DETAILS=expanded` to restore the previous behavior. (#239)
 
 ## [0.6.1] - 2026-05-26

--- a/pkg-py/src/querychat/_shiny.py
+++ b/pkg-py/src/querychat/_shiny.py
@@ -407,7 +407,7 @@ class QueryChat(QueryChatBase[IntoFrameT]):
             A UI component.
 
         """
-        return mod_ui(id or self.id, preload_viz=has_viz_tool(self.tools), **kwargs)
+        return mod_ui(id or self.id, preload_viz=has_viz_tool(self.tools), greeting=self.greeting, **kwargs)
 
     def server(
         self,
@@ -821,7 +821,7 @@ class QueryChatExpress(QueryChatBase[IntoFrameT]):
             A UI component.
 
         """
-        return mod_ui(id or self.id, preload_viz=has_viz_tool(self.tools), **kwargs)
+        return mod_ui(id or self.id, preload_viz=has_viz_tool(self.tools), greeting=self.greeting, **kwargs)
 
     def df(self) -> IntoFrameT:
         """

--- a/pkg-py/src/querychat/_shiny_module.py
+++ b/pkg-py/src/querychat/_shiny_module.py
@@ -64,7 +64,9 @@ def mod_ui(*, preload_viz: bool = False, greeting: str | None = None, **kwargs):
     kwargs.setdefault("enable_cancel", True)
     kwargs.setdefault("allow_attachments", True)
     if greeting:
-        kwargs.setdefault("greeting", shinychat.chat_greeting(greeting, dismissible=False))
+        kwargs.setdefault(
+            "greeting", shinychat.chat_greeting(greeting, dismissible=False)
+        )
     tag = shinychat.chat_ui(CHAT_ID, **kwargs)
     tag.add_class("querychat")
 
@@ -132,6 +134,9 @@ def mod_server(
     # Reactive values to store state
     sql = ReactiveStringOrNone(None)
     title = ReactiveStringOrNone(None)
+    # Holds a generated greeting so it can be saved and restored on bookmark.
+    # Static greetings live in the UI (chat_ui(greeting=)) and persist already.
+    current_greeting = ReactiveStringOrNone(None)
 
     if not callable(client):
         raise TypeError("mod_server() requires a callable client factory.")
@@ -217,6 +222,13 @@ def mod_server(
         @reactive.effect
         @reactive.event(input[f"{CHAT_ID}_greeting_requested"])
         async def _handle_greeting_requested():
+            # Re-display a restored greeting rather than generating a new one.
+            existing = current_greeting.get()
+            if existing is not None:
+                await chat_ui.set_greeting(
+                    shinychat.chat_greeting(existing, dismissible=False)
+                )
+                return
             warnings.warn(
                 "No greeting provided to `QueryChat()`. Using the LLM `client` to generate one now. "
                 "For faster startup, lower cost, and determinism, consider providing a greeting "
@@ -226,7 +238,13 @@ def mod_server(
             )
             greeting_client = client(tools=None)
             stream = await greeting_client.stream_async(GREETING_PROMPT, echo="none")
-            await chat_ui.set_greeting(shinychat.chat_greeting(stream, dismissible=False))
+            await chat_ui.set_greeting(
+                shinychat.chat_greeting(stream, dismissible=False)
+            )
+            # Capture the generated greeting so it can be bookmarked and restored.
+            last_turn = greeting_client.get_last_turn(role="assistant")
+            if last_turn is not None:
+                current_greeting.set(last_turn.text)
 
     # Handle update button clicks
     @reactive.effect
@@ -254,16 +272,26 @@ def mod_server(
             vals = x.values
             vals["querychat_sql"] = sql.get()
             vals["querychat_title"] = title.get()
+            greeting_val = current_greeting.get()
+            if greeting_val is not None:
+                vals["querychat_greeting"] = greeting_val
             if viz_widgets:
                 vals["querychat_viz_widgets"] = viz_widgets
 
         @session.bookmark.on_restore
-        def _on_restore(x: RestoreState) -> None:
+        async def _on_restore(x: RestoreState) -> None:
             vals = x.values
             if "querychat_sql" in vals:
                 sql.set(vals["querychat_sql"])
             if "querychat_title" in vals:
                 title.set(vals["querychat_title"])
+            if "querychat_greeting" in vals:
+                current_greeting.set(vals["querychat_greeting"])
+                await chat_ui.set_greeting(
+                    shinychat.chat_greeting(
+                        vals["querychat_greeting"], dismissible=False
+                    )
+                )
             if "querychat_viz_widgets" in vals:
                 restored = restore_viz_widgets(
                     data_source, vals["querychat_viz_widgets"]

--- a/pkg-py/src/querychat/_shiny_module.py
+++ b/pkg-py/src/querychat/_shiny_module.py
@@ -136,6 +136,10 @@ def mod_server(
     title = ReactiveStringOrNone(None)
     # Holds a generated greeting so it can be saved and restored on bookmark.
     # Static greetings live in the UI (chat_ui(greeting=)) and persist already.
+    # Workaround for posit-dev/shinychat#253: shinychat does not bookmark
+    # greetings or expose their state. If that issue is fixed, this value, the
+    # get_last_turn() capture below, and the greeting handling in
+    # on_bookmark/on_restore can be dropped (and the shinychat minimum bumped).
     current_greeting = ReactiveStringOrNone(None)
 
     if not callable(client):

--- a/pkg-py/src/querychat/_shiny_module.py
+++ b/pkg-py/src/querychat/_shiny_module.py
@@ -57,12 +57,14 @@ ServerClient = chatlas.Chat | _DeferredStubChatClient
 
 
 @module.ui
-def mod_ui(*, preload_viz: bool = False, **kwargs):
+def mod_ui(*, preload_viz: bool = False, greeting: str | None = None, **kwargs):
     css_path = Path(__file__).parent / "static" / "css" / "styles.css"
     js_path = Path(__file__).parent / "static" / "js" / "querychat.js"
 
     kwargs.setdefault("enable_cancel", True)
     kwargs.setdefault("allow_attachments", True)
+    if greeting:
+        kwargs.setdefault("greeting", shinychat.chat_greeting(greeting, dismissible=False))
     tag = shinychat.chat_ui(CHAT_ID, **kwargs)
     tag.add_class("querychat")
 
@@ -130,7 +132,6 @@ def mod_server(
     # Reactive values to store state
     sql = ReactiveStringOrNone(None)
     title = ReactiveStringOrNone(None)
-    has_greeted = reactive.value[bool](False)  # noqa: FBT003
 
     if not callable(client):
         raise TypeError("mod_server() requires a callable client factory.")
@@ -211,14 +212,11 @@ def mod_server(
     def _handle_cancel():
         ctrl.cancel()
 
-    @reactive.effect
-    async def greet_on_startup():
-        if has_greeted():
-            return
+    if greeting is None:
 
-        if greeting:
-            await chat_ui.append_message(greeting)
-        elif greeting is None:
+        @reactive.effect
+        @reactive.event(input[f"{CHAT_ID}_greeting_requested"])
+        async def _handle_greeting_requested():
             warnings.warn(
                 "No greeting provided to `QueryChat()`. Using the LLM `client` to generate one now. "
                 "For faster startup, lower cost, and determinism, consider providing a greeting "
@@ -226,10 +224,9 @@ def mod_server(
                 GreetWarning,
                 stacklevel=2,
             )
-            stream = await chat.stream_async(GREETING_PROMPT, echo="none")
-            await chat_ui.append_message_stream(stream)
-
-        has_greeted.set(True)
+            greeting_client = client(tools=None)
+            stream = await greeting_client.stream_async(GREETING_PROMPT, echo="none")
+            await chat_ui.set_greeting(shinychat.chat_greeting(stream, dismissible=False))
 
     # Handle update button clicks
     @reactive.effect
@@ -257,7 +254,6 @@ def mod_server(
             vals = x.values
             vals["querychat_sql"] = sql.get()
             vals["querychat_title"] = title.get()
-            vals["querychat_has_greeted"] = has_greeted.get()
             if viz_widgets:
                 vals["querychat_viz_widgets"] = viz_widgets
 
@@ -268,8 +264,6 @@ def mod_server(
                 sql.set(vals["querychat_sql"])
             if "querychat_title" in vals:
                 title.set(vals["querychat_title"])
-            if "querychat_has_greeted" in vals:
-                has_greeted.set(vals["querychat_has_greeted"])
             if "querychat_viz_widgets" in vals:
                 restored = restore_viz_widgets(
                     data_source, vals["querychat_viz_widgets"]

--- a/pkg-py/src/querychat/_shiny_module.py
+++ b/pkg-py/src/querychat/_shiny_module.py
@@ -227,6 +227,9 @@ def mod_server(
         @reactive.event(input[f"{CHAT_ID}_greeting_requested"])
         async def _handle_greeting_requested():
             # Re-display a restored greeting rather than generating a new one.
+            # On empty-chat restore both this and on_restore set the greeting
+            # (harmless, identical content); on non-empty restore this never
+            # fires, so on_restore is the only path that re-displays.
             existing = current_greeting.get()
             if existing is not None:
                 await chat_ui.set_greeting(

--- a/pkg-py/tests/playwright/test_01_hello_app.py
+++ b/pkg-py/tests/playwright/test_01_hello_app.py
@@ -40,7 +40,8 @@ class Test01HelloApp:
 
     def test_welcome_message_appears(self) -> None:
         """INIT-02: Chat shows LLM greeting."""
-        expect(self.chat.loc_messages).to_contain_text("Hello", timeout=30000)
+        greeting = self.chat.loc.locator(".shiny-chat-greeting")
+        expect(greeting).to_contain_text("Hello", timeout=30000)
 
     def test_default_sql_query_shown(self) -> None:
         """INIT-03: SQL panel shows default query."""
@@ -66,7 +67,8 @@ class Test01HelloApp:
 
     def test_suggestion_links_present(self) -> None:
         """INIT-07: Suggestions are visible in greeting."""
-        expect(self.chat.loc_messages).to_contain_text(
+        greeting = self.chat.loc.locator(".shiny-chat-greeting")
+        expect(greeting).to_contain_text(
             re.compile(r"survived|class|age", re.IGNORECASE), timeout=30000
         )
 

--- a/pkg-py/tests/playwright/test_02_prompt_app.py
+++ b/pkg-py/tests/playwright/test_02_prompt_app.py
@@ -37,7 +37,8 @@ class Test02PromptApp:
     def test_custom_greeting_appears(self) -> None:
         """INIT-02: Custom greeting from greeting.md is shown."""
         # The custom greeting should contain content from greeting.md
-        expect(self.chat.loc_messages).to_contain_text("Hello", timeout=30000)
+        greeting = self.chat.loc.locator(".shiny-chat-greeting")
+        expect(greeting).to_contain_text("Hello", timeout=30000)
 
     def test_default_sql_query_shown(self) -> None:
         """INIT-03: SQL panel shows default query."""

--- a/pkg-py/tests/playwright/test_03_sidebar_apps.py
+++ b/pkg-py/tests/playwright/test_03_sidebar_apps.py
@@ -44,7 +44,8 @@ class Test03SidebarExpress:
 
     def test_welcome_message_appears(self) -> None:
         """Chat shows LLM greeting."""
-        expect(self.chat.loc_messages).to_contain_text("Hello", timeout=30000)
+        greeting = self.chat.loc.locator(".shiny-chat-greeting")
+        expect(greeting).to_contain_text("Hello", timeout=30000)
 
     def test_card_header_initial(self) -> None:
         """Card header shows 'Titanic Dataset' initially."""
@@ -127,7 +128,8 @@ class Test03SidebarCore:
 
     def test_welcome_message_appears(self) -> None:
         """Chat shows LLM greeting."""
-        expect(self.chat.loc_messages).to_contain_text("Hello", timeout=30000)
+        greeting = self.chat.loc.locator(".shiny-chat-greeting")
+        expect(greeting).to_contain_text("Hello", timeout=30000)
 
     def test_card_header_initial(self) -> None:
         """Card header shows 'Titanic Dataset' initially."""

--- a/pkg-py/tests/playwright/test_10_viz_inline.py
+++ b/pkg-py/tests/playwright/test_10_viz_inline.py
@@ -29,9 +29,8 @@ class TestInlineVisualization:
         """Navigate to the viz app before each test."""
         page.goto(app_10_viz)
         page.wait_for_selector("shiny-chat-container", timeout=30000)
-        expect(chat_10_viz.loc_latest_message).to_contain_text(
-            "Welcome", timeout=30000
-        )
+        greeting = chat_10_viz.loc.locator(".shiny-chat-greeting")
+        expect(greeting).to_contain_text("Welcome", timeout=30000)
         self.page = page
         self.chat = chat_10_viz
 

--- a/pkg-py/tests/playwright/test_11_viz_footer.py
+++ b/pkg-py/tests/playwright/test_11_viz_footer.py
@@ -46,7 +46,8 @@ def _send_viz_prompt(
     """Navigate to the viz app and trigger a visualization before each test."""
     page.goto(app_10_viz)
     page.wait_for_selector("shiny-chat-container", timeout=30_000)
-    expect(chat_10_viz.loc_latest_message).to_contain_text("Welcome", timeout=30_000)
+    greeting = chat_10_viz.loc.locator(".shiny-chat-greeting")
+    expect(greeting).to_contain_text("Welcome", timeout=30_000)
 
     chat_10_viz.set_user_input(VIZ_PROMPT)
     chat_10_viz.send_user_input(method="click")

--- a/pkg-py/tests/playwright/test_12_viz_bookmark.py
+++ b/pkg-py/tests/playwright/test_12_viz_bookmark.py
@@ -78,9 +78,8 @@ class TestVizBookmarkRestore:
 
         page.goto(app_viz_bookmark)
         page.wait_for_selector("shiny-chat-container", timeout=30_000)
-        expect(chat_viz_bookmark.loc_latest_message).to_contain_text(
-            "Welcome", timeout=30_000
-        )
+        greeting = chat_viz_bookmark.loc.locator(".shiny-chat-greeting")
+        expect(greeting).to_contain_text("Welcome", timeout=30_000)
 
         self.pre_viz_url = page.url
 

--- a/pkg-r/NEWS.md
+++ b/pkg-r/NEWS.md
@@ -6,6 +6,10 @@
 
 * File attachments are now enabled by default in the Shiny chat UI. Users can attach images, PDFs, and text files to their messages and the LLM will receive them. Disable with `allow_attachments = FALSE` in `mod_ui()` or `QueryChat$ui()`. (#253)
 
+## Improvements
+
+* Chat greetings now use shinychat's greeting API (requires shinychat >= 0.4.0). A provided `greeting` renders instantly when the app loads, and when no `greeting` is given one is generated on demand without being added to the conversation history. Generated greetings are now preserved across bookmark/restore. (#249)
+
 # querychat 0.3.0
 
 ## New features

--- a/pkg-r/R/QueryChat.R
+++ b/pkg-r/R/QueryChat.R
@@ -681,7 +681,7 @@ QueryChat <- R6::R6Class(
       # implicitly by UI functions like shinychat.chat_ui().
       id <- id %||% namespaced_id(self$id)
 
-      mod_ui(id, ...)
+      mod_ui(id, ..., greeting = self$greeting)
     },
 
     #' @description

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -1,6 +1,13 @@
 # Main module UI function
-mod_ui <- function(id, ..., enable_cancel = TRUE, allow_attachments = TRUE) {
+mod_ui <- function(id, ..., greeting = NULL, enable_cancel = TRUE, allow_attachments = TRUE) {
   ns <- shiny::NS(id)
+
+  if (!is.null(greeting) && any(nzchar(greeting))) {
+    greeting <- shinychat::chat_greeting(greeting, dismissible = FALSE)
+  } else {
+    greeting <- NULL
+  }
+
   htmltools::tagList(
     htmltools::htmlDependency(
       "querychat",
@@ -16,6 +23,7 @@ mod_ui <- function(id, ..., enable_cancel = TRUE, allow_attachments = TRUE) {
       class = "querychat",
       enable_cancel = enable_cancel,
       allow_attachments = allow_attachments,
+      greeting = greeting,
       ...
     )
   )
@@ -33,7 +41,6 @@ mod_server <- function(
   shiny::moduleServer(id, function(input, output, session) {
     current_title <- shiny::reactiveVal(NULL, label = "current_title")
     current_query <- shiny::reactiveVal(NULL, label = "current_query")
-    has_greeted <- shiny::reactiveVal(FALSE, label = "has_greeted")
     filtered_df <- shiny::reactive(label = "filtered_df", {
       data_source$execute_query(query = current_query())
     })
@@ -84,30 +91,25 @@ mod_server <- function(
       session = session
     )
 
-    # Prepopulate the chat UI with a welcome message that appears to be from the
-    # chat model (but is actually hard-coded). This is just for the user, not for
-    # the chat model to see.
-    shiny::observe(label = "greet_on_startup", {
-      if (has_greeted()) {
-        return()
-      }
-
-      greeting_content <- if (!is.null(greeting) && any(nzchar(greeting))) {
-        greeting
-      } else {
-        cli::cli_warn(
-          c(
+    if (is.null(greeting)) {
+      shiny::observeEvent(
+        input$chat_greeting_requested,
+        label = "on_greeting_requested",
+        {
+          cli::cli_warn(c(
             "No {.arg greeting} provided to {.fn QueryChat}. Using the LLM {.arg client} to generate one now.",
             "i" = "For faster startup, lower cost, and determinism, consider providing a {.arg greeting} to {.fn QueryChat}.",
             "i" = "You can use your {.help querychat::QueryChat} object's {.fn $generate_greeting} method to generate a greeting."
+          ))
+          greeting_client <- client(tools = NULL)
+          stream <- greeting_client$stream_async(GREETING_PROMPT)
+          shinychat::chat_set_greeting(
+            "chat",
+            shinychat::chat_greeting(stream, dismissible = FALSE)
           )
-        )
-        chat$stream_async(GREETING_PROMPT)
-      }
-
-      shinychat::chat_append("chat", greeting_content)
-      has_greeted(TRUE)
-    })
+        }
+      )
+    }
 
     ctrl <- ellmer::stream_controller()
 
@@ -151,7 +153,6 @@ mod_server <- function(
       shiny::onBookmark(function(state) {
         state$values$querychat_sql <- current_query()
         state$values$querychat_title <- current_title()
-        state$values$querychat_has_greeted <- has_greeted()
         if (length(viz_widgets) > 0) {
           state$values$querychat_viz_widgets <- viz_widgets
         }
@@ -163,9 +164,6 @@ mod_server <- function(
         }
         if (!is.null(state$values$querychat_title)) {
           current_title(state$values$querychat_title)
-        }
-        if (!is.null(state$values$querychat_has_greeted)) {
-          has_greeted(state$values$querychat_has_greeted)
         }
         if (!is.null(state$values$querychat_viz_widgets)) {
           restored <- restore_viz_widgets(

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -43,6 +43,10 @@ mod_server <- function(
     current_query <- shiny::reactiveVal(NULL, label = "current_query")
     # Holds a generated greeting so it can be saved and restored on bookmark.
     # Static greetings live in the UI (chat_ui(greeting=)) and persist already.
+    # Workaround for posit-dev/shinychat#253: shinychat does not bookmark
+    # greetings or expose their state. If that issue is fixed, this reactiveVal,
+    # the last_turn() capture below, and the greeting handling in
+    # onBookmark/onRestore can be dropped (and the shinychat minimum bumped).
     current_greeting <- shiny::reactiveVal(NULL, label = "current_greeting")
     filtered_df <- shiny::reactive(label = "filtered_df", {
       data_source$execute_query(query = current_query())

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -104,6 +104,9 @@ mod_server <- function(
         label = "on_greeting_requested",
         {
           # Re-display a restored greeting rather than generating a new one.
+          # On empty-chat restore both this and onRestore set the greeting
+          # (harmless, identical content); on non-empty restore this never fires,
+          # so onRestore is the only path that re-displays.
           if (!is.null(current_greeting())) {
             shinychat::chat_set_greeting(
               "chat",

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -1,5 +1,11 @@
 # Main module UI function
-mod_ui <- function(id, ..., greeting = NULL, enable_cancel = TRUE, allow_attachments = TRUE) {
+mod_ui <- function(
+  id,
+  ...,
+  greeting = NULL,
+  enable_cancel = TRUE,
+  allow_attachments = TRUE
+) {
   ns <- shiny::NS(id)
 
   if (!is.null(greeting) && any(nzchar(greeting))) {

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -41,6 +41,9 @@ mod_server <- function(
   shiny::moduleServer(id, function(input, output, session) {
     current_title <- shiny::reactiveVal(NULL, label = "current_title")
     current_query <- shiny::reactiveVal(NULL, label = "current_query")
+    # Holds a generated greeting so it can be saved and restored on bookmark.
+    # Static greetings live in the UI (chat_ui(greeting=)) and persist already.
+    current_greeting <- shiny::reactiveVal(NULL, label = "current_greeting")
     filtered_df <- shiny::reactive(label = "filtered_df", {
       data_source$execute_query(query = current_query())
     })
@@ -96,6 +99,14 @@ mod_server <- function(
         input$chat_greeting_requested,
         label = "on_greeting_requested",
         {
+          # Re-display a restored greeting rather than generating a new one.
+          if (!is.null(current_greeting())) {
+            shinychat::chat_set_greeting(
+              "chat",
+              shinychat::chat_greeting(current_greeting(), dismissible = FALSE)
+            )
+            return()
+          }
           cli::cli_warn(c(
             "No {.arg greeting} provided to {.fn QueryChat}. Using the LLM {.arg client} to generate one now.",
             "i" = "For faster startup, lower cost, and determinism, consider providing a {.arg greeting} to {.fn QueryChat}.",
@@ -103,10 +114,14 @@ mod_server <- function(
           ))
           greeting_client <- client(tools = NULL)
           stream <- greeting_client$stream_async(GREETING_PROMPT)
-          shinychat::chat_set_greeting(
+          p <- shinychat::chat_set_greeting(
             "chat",
             shinychat::chat_greeting(stream, dismissible = FALSE)
           )
+          # Capture the generated greeting so it can be bookmarked and restored.
+          promises::then(p, function(value) {
+            current_greeting(greeting_client$last_turn()@text)
+          })
         }
       )
     }
@@ -153,6 +168,9 @@ mod_server <- function(
       shiny::onBookmark(function(state) {
         state$values$querychat_sql <- current_query()
         state$values$querychat_title <- current_title()
+        if (!is.null(current_greeting())) {
+          state$values$querychat_greeting <- current_greeting()
+        }
         if (length(viz_widgets) > 0) {
           state$values$querychat_viz_widgets <- viz_widgets
         }
@@ -164,6 +182,17 @@ mod_server <- function(
         }
         if (!is.null(state$values$querychat_title)) {
           current_title(state$values$querychat_title)
+        }
+        if (!is.null(state$values$querychat_greeting)) {
+          current_greeting(state$values$querychat_greeting)
+          shinychat::chat_set_greeting(
+            "chat",
+            shinychat::chat_greeting(
+              state$values$querychat_greeting,
+              dismissible = FALSE
+            ),
+            session = session
+          )
         }
         if (!is.null(state$values$querychat_viz_widgets)) {
           restored <- restore_viz_widgets(


### PR DESCRIPTION
## Summary

Migrates greeting handling in both the R and Python packages onto the first-class greeting API in shinychat (which both packages already require at `>= 0.4.0`), replacing the old "append the greeting as a permanent assistant message on startup" pattern.

- **Static greetings render in the UI** via `chat_ui(greeting=)` / `chat_greeting()` — shown instantly on load with no server round-trip, and they persist across bookmark/restore for free because they're part of the UI definition.
- **Generated greetings (when no `greeting` is provided)** now use the `{id}_greeting_requested` input + `chat_set_greeting()` / `Chat.set_greeting()`, instead of an always-running startup observer/effect. They're generated on an **isolated client** (`client(tools = NULL)` / `client(tools=None)`) so `GREETING_PROMPT` and its response stay out of the live conversation's model history. The existing "no greeting provided" warning is preserved.
- **Drops the `has_greeted` bookkeeping** (reactive value + its bookmark save/restore). shinychat now owns greeting visibility and dismissal state.
- Greetings use `dismissible = FALSE` so the welcome + suggestion cards remain visible after the conversation starts (closest to the prior permanent-message behavior).

### Bookmark-restore workaround (shinychat#253)

shinychat's bookmarking only round-trips the ellmer/chatlas client's chat turns; a greeting set via `chat_set_greeting()` is neither a turn nor exposed as readable state, so generated greetings are lost on restore. Until [posit-dev/shinychat#253](https://github.com/posit-dev/shinychat/issues/253) is fixed, this PR captures the generated greeting text (from the isolated client's last turn) and saves/restores it through the module's own `onBookmark`/`onRestore` hooks. The `greeting_requested` handler reuses a restored greeting instead of regenerating. Static greetings need no tracking. Source comments at each site point back to #253 with removal hints for when it lands.

## Verification

**Static greeting (persists for free):**

```r
library(querychat)
qc <- QueryChat$new(mtcars, greeting = "Welcome! Ask me about the cars dataset.")
qc$app()
```

The greeting renders immediately on load (no LLM call). Bookmark the app and reopen the URL — the greeting is still there.

**Generated greeting (captured + restored via the workaround):**

```r
qc <- QueryChat$new(mtcars)  # no greeting -> generated on first load
qc$app()
```

A warning is emitted and a greeting is generated once. Send a message, bookmark, then reopen the bookmark URL: the same generated greeting is restored above the conversation rather than disappearing or being regenerated.

Python mirrors both behaviors (`QueryChat(...).app()` / `from_*` constructors).