### PR TITLE
feat(pkg-r): support sqlite engine in PinSource

### DIFF
--- a/pkg-py/CHANGELOG.md
+++ b/pkg-py/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### New features
+
+* Added `PinSource`, a data source for chatting with datasets pinned to a [pins](https://pins.rstudio.com/) board. Works with parquet, CSV, JSON, and Arrow pins, and uses the pin's title, description, and tags as the default data description. Install the optional dependency with `pip install querychat[pins]`. (#246)
+
 ### Improvements
 
 * The query tool result card now starts collapsed by default. Users can still expand it to see the SQL query and results. Set `QUERYCHAT_TOOL_DETAILS=expanded` to restore the previous behavior. (#239)

--- a/pkg-r/NEWS.md
+++ b/pkg-r/NEWS.md
@@ -1,5 +1,9 @@
 # querychat (development version)
 
+## New features
+
+* Added `PinSource`, a data source for chatting with datasets pinned to a [pins](https://pins.rstudio.com/) board. Works with parquet, CSV, JSON, and RDS pins, and uses the pin's title, description, and tags as the default data description. (#246)
+
 # querychat 0.3.0
 
 ## New features

--- a/pkg-r/R/DataFrameSource.R
+++ b/pkg-r/R/DataFrameSource.R
@@ -69,28 +69,27 @@ DataFrameSource <- R6::R6Class(
       self$table_name <- table_name
       private$colnames <- colnames(df)
 
-      # Create in-memory connection and register the data frame
-      if (engine == "duckdb") {
-        check_installed("duckdb")
-
-        private$conn <- DBI::dbConnect(duckdb::duckdb(), dbdir = ":memory:")
-
-        duckdb::duckdb_register(
-          private$conn,
-          table_name,
-          df,
-          experimental = FALSE
-        )
-
-        duckdb_lock_down(private$conn)
-      } else if (engine == "sqlite") {
-        check_installed("RSQLite")
-        private$conn <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
-        DBI::dbWriteTable(private$conn, table_name, df)
-      }
+      private$conn <- new_dataframe_connection(df, table_name, engine)
     }
   )
 )
+
+# Create an in-memory connection and register `df` as `table_name` using the
+# given engine ("duckdb" or "sqlite"). The engine must already be resolved and
+# validated by the caller. Returns the DBI connection.
+new_dataframe_connection <- function(df, table_name, engine) {
+  if (engine == "duckdb") {
+    check_installed("duckdb")
+    conn <- DBI::dbConnect(duckdb::duckdb(), dbdir = ":memory:")
+    duckdb::duckdb_register(conn, table_name, df, experimental = FALSE)
+    duckdb_lock_down(conn)
+  } else {
+    check_installed("RSQLite")
+    conn <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+    DBI::dbWriteTable(conn, table_name, df)
+  }
+  conn
+}
 
 get_default_dataframe_engine <- function() {
   if (is_installed("duckdb")) {

--- a/pkg-r/R/PinSource.R
+++ b/pkg-r/R/PinSource.R
@@ -2,14 +2,16 @@
 #'
 #' @description
 #' A DataSource implementation that reads data from a
-#' [pins](https://pins.rstudio.com/) board. For pin types that DuckDB can read
-#' natively (parquet, CSV, JSON), the data is loaded directly from the cached
-#' pin files into DuckDB without deserializing into R. For other pin types
-#' (e.g. RDS), the data is deserialized via `pin_read()` and must produce
-#' a data frame (or tibble) to be registered with DuckDB.
+#' [pins](https://pins.rstudio.com/) board. When the `"duckdb"` engine is used
+#' and the pin type is one DuckDB can read natively (parquet, CSV, JSON), the
+#' data is loaded directly from the cached pin files into DuckDB without
+#' deserializing into R. For other pin types (e.g. RDS), or when the `"sqlite"`
+#' engine is used, the data is deserialized via `pin_read()` and must produce
+#' a data frame (or tibble), which is then registered with the chosen engine
+#' just like [DataFrameSource].
 #'
-#' After loading, DuckDB's external file access is locked down so that
-#' LLM-generated SQL cannot reach the filesystem.
+#' When loaded into DuckDB, the connection's external file access is locked
+#' down so that LLM-generated SQL cannot reach the filesystem.
 #'
 #' If the pin has a title, description, or tags, [QueryChat] uses them as
 #' the default `data_description`, which you can override.
@@ -68,24 +70,43 @@ PinSource <- R6::R6Class(
     #'   the pin name.
     #' @param version Pin version to read. If `NULL` (default), reads the
     #'   latest version.
+    #' @param engine Database engine to use: `"duckdb"` or `"sqlite"`. Set the
+    #'   global option `querychat.DataFrameSource.engine` to specify the default
+    #'   engine. If `NULL` (default), uses the first available engine from
+    #'   duckdb or RSQLite (in that order). Parquet, CSV, and JSON pins are read
+    #'   most efficiently with the `"duckdb"` engine; with `"sqlite"` they are
+    #'   deserialized via `pin_read()` instead.
     #'
     #' @return A new PinSource object
-    initialize = function(board, name, ..., table_name = name, version = NULL) {
+    initialize = function(
+      board,
+      name,
+      ...,
+      table_name = name,
+      version = NULL,
+      engine = getOption("querychat.DataFrameSource.engine", NULL)
+    ) {
       rlang::check_installed("pins", reason = "to use PinSource.")
-      rlang::check_installed("duckdb", reason = "to use PinSource.")
       rlang::check_dots_empty()
+
+      engine <- engine %||% get_default_dataframe_engine()
+      engine <- tolower(engine)
+      arg_match(engine, c("duckdb", "sqlite"))
 
       table_name <- sanitize_table_name(table_name)
       private$.pin_meta <- pins::pin_meta(board, name, version = version)
 
       pin_type <- private$.pin_meta$type
-      con <- DBI::dbConnect(duckdb::duckdb())
-      con_owned <- FALSE
-      on.exit(if (!con_owned) DBI::dbDisconnect(con), add = TRUE)
-
       duckdb_file_types <- c("parquet", "csv", "json")
+      use_duckdb_file_read <- engine == "duckdb" &&
+        pin_type %in% duckdb_file_types
 
-      if (pin_type %in% duckdb_file_types) {
+      if (use_duckdb_file_read) {
+        check_installed("duckdb")
+        con <- DBI::dbConnect(duckdb::duckdb())
+        con_owned <- FALSE
+        on.exit(if (!con_owned) DBI::dbDisconnect(con), add = TRUE)
+
         paths <- pins::pin_download(board, name, version = version)
         if (length(paths) != 1) {
           cli::cli_abort(
@@ -110,17 +131,24 @@ PinSource <- R6::R6Class(
           quoted_path
         )
         DBI::dbExecute(con, sql)
+        duckdb_lock_down(con)
       } else {
+        if (engine == "sqlite" && pin_type %in% duckdb_file_types) {
+          cli::cli_warn(c(
+            "Reading {pin_type} pin {.val {name}} into SQLite.",
+            "i" = "The {.pkg duckdb} engine reads {pin_type} pins more efficiently. Install {.pkg duckdb} or pass {.code engine = \"duckdb\"} to read the pin files directly."
+          ))
+        }
         data <- pins::pin_read(board, name, version = version)
         if (!is.data.frame(data)) {
           cli::cli_abort(
             "Pin {.val {name}} contains {.obj_type_friendly {data}}, not a data frame."
           )
         }
-        duckdb::dbWriteTable(con, table_name, data)
+        con <- new_dataframe_connection(data, table_name, engine)
+        con_owned <- FALSE
+        on.exit(if (!con_owned) DBI::dbDisconnect(con), add = TRUE)
       }
-
-      duckdb_lock_down(con)
 
       super$initialize(con, table_name)
       con_owned <- TRUE

--- a/pkg-r/man/PinSource.Rd
+++ b/pkg-r/man/PinSource.Rd
@@ -5,14 +5,16 @@
 \title{Pin Source}
 \description{
 A DataSource implementation that reads data from a
-\href{https://pins.rstudio.com/}{pins} board. For pin types that DuckDB can read
-natively (parquet, CSV, JSON), the data is loaded directly from the cached
-pin files into DuckDB without deserializing into R. For other pin types
-(e.g. RDS), the data is deserialized via \code{pin_read()} and must produce
-a data frame (or tibble) to be registered with DuckDB.
+\href{https://pins.rstudio.com/}{pins} board. When the \code{"duckdb"} engine is used
+and the pin type is one DuckDB can read natively (parquet, CSV, JSON), the
+data is loaded directly from the cached pin files into DuckDB without
+deserializing into R. For other pin types (e.g. RDS), or when the \code{"sqlite"}
+engine is used, the data is deserialized via \code{pin_read()} and must produce
+a data frame (or tibble), which is then registered with the chosen engine
+just like \link{DataFrameSource}.
 
-After loading, DuckDB's external file access is locked down so that
-LLM-generated SQL cannot reach the filesystem.
+When loaded into DuckDB, the connection's external file access is locked
+down so that LLM-generated SQL cannot reach the filesystem.
 
 If the pin has a title, description, or tags, \link{QueryChat} uses them as
 the default \code{data_description}, which you can override.
@@ -86,7 +88,14 @@ if (rlang::is_installed(c("pins", "duckdb"))) {
   Create a new PinSource
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{PinSource$new(board, name, ..., table_name = name, version = NULL)}
+    \preformatted{PinSource$new(
+  board,
+  name,
+  ...,
+  table_name = name,
+  version = NULL,
+  engine = getOption("querychat.DataFrameSource.engine", NULL)
+)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -100,6 +109,12 @@ if (rlang::is_installed(c("pins", "duckdb"))) {
 the pin name.}
       \item{\code{version}}{Pin version to read. If \code{NULL} (default), reads the
 latest version.}
+      \item{\code{engine}}{Database engine to use: \code{"duckdb"} or \code{"sqlite"}. Set the
+global option \code{querychat.DataFrameSource.engine} to specify the default
+engine. If \code{NULL} (default), uses the first available engine from
+duckdb or RSQLite (in that order). Parquet, CSV, and JSON pins are read
+most efficiently with the \code{"duckdb"} engine; with \code{"sqlite"} they are
+deserialized via \code{pin_read()} instead.}
     }
     \if{html}{\out{</div>}}
   }

--- a/pkg-r/tests/testthat/test-PinSource.R
+++ b/pkg-r/tests/testthat/test-PinSource.R
@@ -5,11 +5,18 @@ local_pin_source <- function(
   ...,
   table_name = name,
   version = NULL,
+  engine = NULL,
   env = parent.frame()
 ) {
   board <- pins::board_temp()
   suppressMessages(pins::pin_write(board, data, name, type = type, ...))
-  ps <- PinSource$new(board, name, table_name = table_name, version = version)
+  ps <- PinSource$new(
+    board,
+    name,
+    table_name = table_name,
+    version = version,
+    engine = engine
+  )
   withr::defer(ps$cleanup(), envir = env)
   ps
 }
@@ -101,6 +108,34 @@ describe("PinSource$new() — in-memory path (rds)", {
       PinSource$new(board, "list_pin"),
       "not a data frame"
     )
+  })
+})
+
+describe("PinSource$new() — engine argument", {
+  skip_if_not_installed("pins")
+  skip_if_not_installed("RSQLite")
+
+  it("uses SQLite for a data-frame (rds) pin", {
+    ps <- local_pin_source(name = "rds_data", type = "rds", engine = "sqlite")
+
+    expect_equal(ps$get_db_type(), "SQLite")
+    result <- ps$execute_query("SELECT * FROM rds_data")
+    expect_s3_class(result, "data.frame")
+    expect_equal(nrow(result), 10)
+  })
+
+  it("warns and falls back to pin_read for a file-type pin", {
+    expect_warning(
+      ps <- local_pin_source(
+        name = "csv_data",
+        type = "csv",
+        engine = "sqlite"
+      ),
+      "more efficiently"
+    )
+
+    expect_equal(ps$get_db_type(), "SQLite")
+    expect_equal(nrow(ps$execute_query("SELECT * FROM csv_data")), 10)
   })
 })
 


### PR DESCRIPTION
## Summary

`PinSource` previously always used DuckDB, even for pins that deserialize to a plain data frame. Since `duckdb` and `RSQLite` are both optional (`Suggests`) in the R package, a user who installed only RSQLite could use `DataFrameSource` but not `PinSource`. This PR aligns `PinSource` with `DataFrameSource`'s engine handling.

Key changes:

- Extracted `DataFrameSource`'s inline connection setup into a shared internal helper, `new_dataframe_connection(df, table_name, engine)`, which creates an in-memory connection, registers the data frame, and applies the DuckDB security lockdown. `DataFrameSource$initialize()` now calls it.
- `PinSource$new()` gains an `engine` argument (default `getOption("querychat.DataFrameSource.engine", NULL)`, resolved via the same `get_default_dataframe_engine()` as `DataFrameSource`). Data-frame pins now share `DataFrameSource`'s code path, so the SQL flavor reported by the inherited `get_db_type()` is resolved consistently.
- The efficient direct DuckDB file read is kept for parquet/CSV/JSON pins under the `duckdb` engine. Requesting `engine = "sqlite"` for those pin types falls back to `pin_read()` with a warning that DuckDB reads them more efficiently.
- `duckdb` is no longer unconditionally required by `PinSource` — it is only needed when actually used.

While here, this PR also backfills a changelog entry for the original `PinSource` feature (#246), which was merged without one, in both `NEWS.md` and the Python `CHANGELOG.md`. The Python side is otherwise intentionally unchanged: `duckdb` is a core dependency there and `DataFrameSource`/`PinSource` are DuckDB-only by design, so no equivalent gap exists.

## Verification

```r
board <- pins::board_temp()
pins::pin_write(board, mtcars, "mtcars", type = "rds")

# Force the SQLite engine for a data-frame pin
ps <- querychat::PinSource$new(board, "mtcars", engine = "sqlite")
ps$get_db_type()
#> [1] "SQLite"
ps$execute_query("SELECT * FROM mtcars WHERE mpg > 30")

# A file-type pin under sqlite warns, then reads via pin_read()
pins::pin_write(board, mtcars, "cars", type = "csv")
ps2 <- querychat::PinSource$new(board, "cars", engine = "sqlite")
#> Warning: Reading csv pin "cars" into SQLite.
#> i The duckdb engine reads csv pins more efficiently. ...
ps2$cleanup()
ps$cleanup()
```

New tests cover the SQLite data-frame path and the file-type fallback warning in `tests/testthat/test-PinSource.R`.