### PR TITLE
test(pkg-py): fix Playwright chat input placeholder assertions

### DIFF
--- a/pkg-py/tests/playwright/test_01_hello_app.py
+++ b/pkg-py/tests/playwright/test_01_hello_app.py
@@ -61,7 +61,7 @@ class Test01HelloApp:
         """INIT-06: Chat input is visible with placeholder."""
         expect(self.chat.loc_input).to_be_visible()
         expect(self.chat.loc_input).to_have_attribute(
-            "placeholder", "Enter a message..."
+            "data-placeholder", "Enter a message..."
         )
 
     def test_suggestion_links_present(self) -> None:

--- a/pkg-py/tests/playwright/test_03_sidebar_apps.py
+++ b/pkg-py/tests/playwright/test_03_sidebar_apps.py
@@ -61,7 +61,7 @@ class Test03SidebarExpress:
         """Chat input is visible with placeholder."""
         expect(self.chat.loc_input).to_be_visible()
         expect(self.chat.loc_input).to_have_attribute(
-            "placeholder", "Enter a message..."
+            "data-placeholder", "Enter a message..."
         )
 
     def test_sidebar_layout(self) -> None:
@@ -144,7 +144,7 @@ class Test03SidebarCore:
         """Chat input is visible with placeholder."""
         expect(self.chat.loc_input).to_be_visible()
         expect(self.chat.loc_input).to_have_attribute(
-            "placeholder", "Enter a message..."
+            "data-placeholder", "Enter a message..."
         )
 
     def test_sidebar_layout(self) -> None:


### PR DESCRIPTION
The Python E2E (Playwright) tests started failing in CI because Shiny's chat input migrated upstream to a TipTap/ProseMirror `contenteditable` div. The placeholder is now exposed via `data-placeholder` instead of the native `placeholder` attribute, so `to_have_attribute("placeholder", ...)` resolved to `None`.

Updated the three affected Shiny-based assertions to check `data-placeholder`. The Gradio test is unchanged since it targets a real `<textarea>` that still uses `placeholder`.