### PR TITLE
feat: file attachment support for Shiny UI

### DIFF
--- a/pkg-py/CHANGELOG.md
+++ b/pkg-py/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### New features
+
+* File attachments are now enabled by default in the Shiny chat UI. Users can attach images, PDFs, and text files to their messages and the LLM will receive them. Disable with `allow_attachments=False` in `mod_ui()` or `QueryChat.ui()`. (#253)
+
 ### Improvements
 
 * The query tool result card now starts collapsed by default. Users can still expand it to see the SQL query and results. Set `QUERYCHAT_TOOL_DETAILS=expanded` to restore the previous behavior. (#239)

--- a/pkg-py/src/querychat/_shiny_module.py
+++ b/pkg-py/src/querychat/_shiny_module.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Generic, TypedDict, Union
 import chatlas
 import shinychat
 from narwhals.stable.v1.typing import IntoFrameT
+from shinychat import Attachment, attachment_to_content
 
 from shiny import module, reactive, ui
 
@@ -61,6 +62,7 @@ def mod_ui(*, preload_viz: bool = False, **kwargs):
     js_path = Path(__file__).parent / "static" / "js" / "querychat.js"
 
     kwargs.setdefault("enable_cancel", True)
+    kwargs.setdefault("allow_attachments", True)
     tag = shinychat.chat_ui(CHAT_ID, **kwargs)
     tag.add_class("querychat")
 
@@ -196,10 +198,12 @@ def mod_server(
     chat_ui = shinychat.Chat(CHAT_ID)
     ctrl = chatlas.StreamController()
 
-    # Handle user input
     @chat_ui.on_user_submit
-    async def _(user_input: str):
-        stream = await chat.stream_async(user_input, echo="none", content="all", controller=ctrl)
+    async def _(user_input: str, attachments: list[Attachment]):
+        contents = [attachment_to_content(a) for a in attachments]
+        stream = await chat.stream_async(
+            user_input, *contents, echo="none", content="all", controller=ctrl
+        )
         await chat_ui.append_message_stream(stream)
 
     @reactive.effect

--- a/pkg-py/tests/playwright/test_13_attachments.py
+++ b/pkg-py/tests/playwright/test_13_attachments.py
@@ -1,0 +1,64 @@
+"""
+Playwright tests for file attachment support in QueryChat's Shiny UI.
+
+Verifies that the attach-file button is rendered and that attached text
+content is forwarded through the on_user_submit handler to the LLM.
+"""
+
+from __future__ import annotations
+
+import re
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from playwright.sync_api import expect
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+    from shinychat.playwright import ChatController
+
+
+class TestAttachments:
+    """Tests for file attachment support in QueryChat."""
+
+    @pytest.fixture(autouse=True)
+    def setup(
+        self, page: Page, app_01_hello: str, chat_01_hello: ChatController
+    ) -> None:
+        page.goto(app_01_hello)
+        page.wait_for_selector("table", timeout=10000)
+        self.page = page
+        self.chat = chat_01_hello
+
+    def test_attachment_button_is_visible_by_default(self) -> None:
+        """ATTACH-01: Attach button renders when allow_attachments=True (the default)."""
+        expect(self.page.locator(".shiny-chat-btn-attach").first).to_be_visible()
+
+    def test_text_attachment_content_reaches_llm(self) -> None:
+        """ATTACH-02: LLM response references content from an attached text file."""
+        unique_word = "QUERYCHAT_ZEPHYR_42"
+
+        with tempfile.NamedTemporaryFile(
+            suffix=".txt", mode="w", delete=False, prefix="querychat_attach_test_"
+        ) as f:
+            f.write(f"Secret word: {unique_word}\n")
+            tmp_path = Path(f.name)
+
+        try:
+            with self.page.expect_file_chooser() as fc_info:
+                self.page.locator(".shiny-chat-btn-attach").first.click()
+            fc_info.value.set_files(str(tmp_path))
+
+            self.chat.set_user_input(
+                "What is the secret word in the attached file? Reply with only the word."
+            )
+            self.chat.send_user_input(method="click")
+
+            self.chat.expect_latest_message(
+                re.compile(unique_word, re.IGNORECASE),
+                timeout=60000,
+            )
+        finally:
+            tmp_path.unlink(missing_ok=True)

--- a/pkg-py/tests/test_shiny_module.py
+++ b/pkg-py/tests/test_shiny_module.py
@@ -1,0 +1,48 @@
+"""Tests for the Shiny module UI and server wiring."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from shiny import ui
+
+
+@pytest.fixture(autouse=True)
+def set_dummy_api_key():
+    old = os.environ.get("OPENAI_API_KEY")
+    os.environ["OPENAI_API_KEY"] = "sk-dummy"
+    yield
+    if old is not None:
+        os.environ["OPENAI_API_KEY"] = old
+    else:
+        del os.environ["OPENAI_API_KEY"]
+
+
+def _fake_chat_ui(*args, **kwargs):
+    """Return a real Tag so htmltools accepts it; stash kwargs for inspection."""
+    _fake_chat_ui.last_kwargs = kwargs
+    return ui.div()
+
+
+_fake_chat_ui.last_kwargs: dict = {}
+
+
+def test_mod_ui_enables_attachments_by_default():
+    """mod_ui() should pass allow_attachments=True to shinychat.chat_ui by default."""
+    from querychat._shiny_module import mod_ui
+
+    with patch("querychat._shiny_module.shinychat.chat_ui", side_effect=_fake_chat_ui):
+        mod_ui("test")  # id is required — @module.ui injects it as first positional arg
+        assert _fake_chat_ui.last_kwargs.get("allow_attachments") is True
+
+
+def test_mod_ui_allow_attachments_can_be_overridden():
+    """Passing allow_attachments=False should disable the affordance."""
+    from querychat._shiny_module import mod_ui
+
+    with patch("querychat._shiny_module.shinychat.chat_ui", side_effect=_fake_chat_ui):
+        mod_ui("test", allow_attachments=False)
+        assert _fake_chat_ui.last_kwargs.get("allow_attachments") is False

--- a/pkg-py/tests/test_shiny_module.py
+++ b/pkg-py/tests/test_shiny_module.py
@@ -46,3 +46,5 @@ def test_mod_ui_allow_attachments_can_be_overridden():
     with patch("querychat._shiny_module.shinychat.chat_ui", side_effect=_fake_chat_ui):
         mod_ui("test", allow_attachments=False)
         assert _fake_chat_ui.last_kwargs.get("allow_attachments") is False
+
+

--- a/pkg-r/NEWS.md
+++ b/pkg-r/NEWS.md
@@ -1,5 +1,9 @@
 # querychat (development version)
 
+## New features
+
+* File attachments are now enabled by default in the Shiny chat UI. Users can attach images, PDFs, and text files to their messages and the LLM will receive them. Disable with `allow_attachments = FALSE` in `mod_ui()` or `QueryChat$ui()`. (#253)
+
 # querychat 0.3.0
 
 ## New features

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -1,5 +1,5 @@
 # Main module UI function
-mod_ui <- function(id, ..., enable_cancel = TRUE) {
+mod_ui <- function(id, ..., enable_cancel = TRUE, allow_attachments = TRUE) {
   ns <- shiny::NS(id)
   htmltools::tagList(
     htmltools::htmlDependency(
@@ -15,6 +15,7 @@ mod_ui <- function(id, ..., enable_cancel = TRUE) {
       height = "100%",
       class = "querychat",
       enable_cancel = enable_cancel,
+      allow_attachments = allow_attachments,
       ...
     )
   )
@@ -94,11 +95,13 @@ mod_server <- function(
       greeting_content <- if (!is.null(greeting) && any(nzchar(greeting))) {
         greeting
       } else {
-        cli::cli_warn(c(
-          "No {.arg greeting} provided to {.fn QueryChat}. Using the LLM {.arg client} to generate one now.",
-          "i" = "For faster startup, lower cost, and determinism, consider providing a {.arg greeting} to {.fn QueryChat}.",
-          "i" = "You can use your {.help querychat::QueryChat} object's {.fn $generate_greeting} method to generate a greeting."
-        ))
+        cli::cli_warn(
+          c(
+            "No {.arg greeting} provided to {.fn QueryChat}. Using the LLM {.arg client} to generate one now.",
+            "i" = "For faster startup, lower cost, and determinism, consider providing a {.arg greeting} to {.fn QueryChat}.",
+            "i" = "You can use your {.help querychat::QueryChat} object's {.fn $generate_greeting} method to generate a greeting."
+          )
+        )
         chat$stream_async(GREETING_PROMPT)
       }
 
@@ -111,7 +114,7 @@ mod_server <- function(
     append_stream_task <- shiny::ExtendedTask$new(
       function(client, user_input, controller = NULL) {
         stream <- client$stream_async(
-          user_input,
+          !!!user_input,
           stream = "content",
           controller = controller
         )

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -113,7 +113,11 @@ mod_server <- function(
 
     append_stream_task <- shiny::ExtendedTask$new(
       function(client, user_input, controller = NULL) {
-        user_input_parts <- if (is.list(user_input)) user_input else list(user_input)
+        user_input_parts <- if (is.list(user_input)) {
+          user_input
+        } else {
+          list(user_input)
+        }
         stream <- client$stream_async(
           !!!user_input_parts,
           stream = "content",

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -113,8 +113,9 @@ mod_server <- function(
 
     append_stream_task <- shiny::ExtendedTask$new(
       function(client, user_input, controller = NULL) {
+        user_input_parts <- if (is.list(user_input)) user_input else list(user_input)
         stream <- client$stream_async(
-          !!!user_input,
+          !!!user_input_parts,
           stream = "content",
           controller = controller
         )

--- a/pkg-r/tests/testthat/test-querychat_module.R
+++ b/pkg-r/tests/testthat/test-querychat_module.R
@@ -51,7 +51,10 @@ test_that("mod_server() passes visualize callback and tools to client factory", 
 test_that("mod_ui() passes allow_attachments = TRUE to shinychat by default", {
   captured <- NULL
   local_mocked_bindings(
-    chat_ui = function(...) { captured <<- list(...); htmltools::div() },
+    chat_ui = function(...) {
+      captured <<- list(...)
+      htmltools::div()
+    },
     .package = "shinychat"
   )
   mod_ui("test")
@@ -61,7 +64,10 @@ test_that("mod_ui() passes allow_attachments = TRUE to shinychat by default", {
 test_that("mod_ui() passes allow_attachments = FALSE when requested", {
   captured <- NULL
   local_mocked_bindings(
-    chat_ui = function(...) { captured <<- list(...); htmltools::div() },
+    chat_ui = function(...) {
+      captured <<- list(...)
+      htmltools::div()
+    },
     .package = "shinychat"
   )
   mod_ui("test", allow_attachments = FALSE)

--- a/pkg-r/tests/testthat/test-querychat_module.R
+++ b/pkg-r/tests/testthat/test-querychat_module.R
@@ -48,12 +48,12 @@ test_that("mod_server() passes visualize callback and tools to client factory", 
   )
 })
 
-test_that("mod_ui() includes allow-attachments attribute by default", {
+test_that("mod_ui() includes allow_attachments attribute by default", {
   skip_if_no_dataframe_engine()
 
   html <- mod_ui("test")
   html_str <- as.character(htmltools::renderTags(html)$html)
-  expect_match(html_str, "allow-attachments")
+  expect_match(html_str, "allow_attachments")
 })
 
 test_that("mod_ui() passes allow_attachments = FALSE when requested", {
@@ -61,7 +61,7 @@ test_that("mod_ui() passes allow_attachments = FALSE when requested", {
 
   html <- mod_ui("test", allow_attachments = FALSE)
   html_str <- as.character(htmltools::renderTags(html)$html)
-  expect_no_match(html_str, "allow-attachments")
+  expect_no_match(html_str, "allow_attachments")
 })
 
 test_that("restored viz widgets survive a second bookmark cycle", {

--- a/pkg-r/tests/testthat/test-querychat_module.R
+++ b/pkg-r/tests/testthat/test-querychat_module.R
@@ -79,8 +79,7 @@ test_that("restored viz widgets survive a second bookmark cycle", {
   }
 
   local_mocked_bindings(
-    chat_restore = function(id, chat, session) {
-    },
+    chat_restore = function(id, chat, session) {},
     .package = "shinychat"
   )
   local_mocked_bindings(

--- a/pkg-r/tests/testthat/test-querychat_module.R
+++ b/pkg-r/tests/testthat/test-querychat_module.R
@@ -48,20 +48,24 @@ test_that("mod_server() passes visualize callback and tools to client factory", 
   )
 })
 
-test_that("mod_ui() includes allow_attachments attribute by default", {
-  skip_if_no_dataframe_engine()
-
-  html <- mod_ui("test")
-  html_str <- as.character(htmltools::renderTags(html)$html)
-  expect_match(html_str, "allow_attachments")
+test_that("mod_ui() passes allow_attachments = TRUE to shinychat by default", {
+  captured <- NULL
+  local_mocked_bindings(
+    chat_ui = function(...) { captured <<- list(...); htmltools::div() },
+    .package = "shinychat"
+  )
+  mod_ui("test")
+  expect_true(isTRUE(captured$allow_attachments))
 })
 
 test_that("mod_ui() passes allow_attachments = FALSE when requested", {
-  skip_if_no_dataframe_engine()
-
-  html <- mod_ui("test", allow_attachments = FALSE)
-  html_str <- as.character(htmltools::renderTags(html)$html)
-  expect_no_match(html_str, "allow_attachments")
+  captured <- NULL
+  local_mocked_bindings(
+    chat_ui = function(...) { captured <<- list(...); htmltools::div() },
+    .package = "shinychat"
+  )
+  mod_ui("test", allow_attachments = FALSE)
+  expect_false(isTRUE(captured$allow_attachments))
 })
 
 test_that("restored viz widgets survive a second bookmark cycle", {

--- a/pkg-r/tests/testthat/test-querychat_module.R
+++ b/pkg-r/tests/testthat/test-querychat_module.R
@@ -48,6 +48,22 @@ test_that("mod_server() passes visualize callback and tools to client factory", 
   )
 })
 
+test_that("mod_ui() includes allow-attachments attribute by default", {
+  skip_if_no_dataframe_engine()
+
+  html <- mod_ui("test")
+  html_str <- as.character(htmltools::renderTags(html)$html)
+  expect_match(html_str, "allow-attachments")
+})
+
+test_that("mod_ui() passes allow_attachments = FALSE when requested", {
+  skip_if_no_dataframe_engine()
+
+  html <- mod_ui("test", allow_attachments = FALSE)
+  html_str <- as.character(htmltools::renderTags(html)$html)
+  expect_no_match(html_str, "allow-attachments")
+})
+
 test_that("restored viz widgets survive a second bookmark cycle", {
   skip_if_no_dataframe_engine()
 
@@ -63,7 +79,8 @@ test_that("restored viz widgets survive a second bookmark cycle", {
   }
 
   local_mocked_bindings(
-    chat_restore = function(id, chat, session) {},
+    chat_restore = function(id, chat, session) {
+    },
     .package = "shinychat"
   )
   local_mocked_bindings(

--- a/pkg-r/tests/testthat/test-viz-tool.R
+++ b/pkg-r/tests/testthat/test-viz-tool.R
@@ -134,10 +134,10 @@ describe("tool_visualize_dashboard()", {
         callback_data <<- data
       }
     )
-    tool(
+    suppressWarnings(tool(
       ggsql = "SELECT * FROM test_table VISUALISE value AS x DRAW histogram",
       title = "Test"
-    )
+    ))
     expect_type(callback_data, "list")
     expect_true(all(c("ggsql", "title", "widget_id") %in% names(callback_data)))
     expect_identical(footer_data$dom_widget_id, footer_data[[3]])
@@ -365,10 +365,10 @@ describe("tool_visualize_dashboard()", {
       update_fn = function(data) {}
     )
 
-    tool(
+    suppressWarnings(tool(
       ggsql = "SELECT * FROM test_table VISUALISE value AS x DRAW histogram",
       title = "Test"
-    )
+    ))
 
     expect_identical(
       footer_data$dom_widget_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ maintainers = [
 dependencies = [
     "duckdb",
     "shiny>=1.6.2",
-    "shinychat>=0.5.1",
+    "shinychat @ git+https://github.com/posit-dev/shinychat.git",
     "htmltools",
     "chatlas>=0.18.0",
     "narwhals>=2.2.0",
@@ -72,8 +72,9 @@ required-environments = [
     "sys_platform == 'darwin'",
 ]
 
-[tool.uv.sources]
-shinychat = { git = "https://github.com/posit-dev/shinychat.git" }
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["pkg-py/src/querychat"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ maintainers = [
 dependencies = [
     "duckdb",
     "shiny>=1.6.2",
-    "shinychat>=0.4.0",
+    "shinychat>=0.5.1",
     "htmltools",
     "chatlas>=0.18.0",
     "narwhals>=2.2.0",
@@ -71,6 +71,9 @@ required-environments = [
     "sys_platform == 'linux' and platform_machine == 'x86_64'",
     "sys_platform == 'darwin'",
 ]
+
+[tool.uv.sources]
+shinychat = { git = "https://github.com/posit-dev/shinychat.git" }
 
 [tool.hatch.build.targets.wheel]
 packages = ["pkg-py/src/querychat"]


### PR DESCRIPTION
## Why this matters

shinychat recently added file attachment support (images, PDFs, text/code files) in [PR #250](https://github.com/posit-dev/shinychat/pull/250). This PR wires that support into querychat's Shiny UI automatically. Since querychat always provides a chatlas/ellmer client, there's nothing for users to configure — the attach button, drag-and-drop, and clipboard paste just appear.

## What changes

**Python** (`_shiny_module.py`):
- `mod_ui()` defaults `allow_attachments=True` via `kwargs.setdefault`
- The `on_user_submit` handler now accepts `(user_input, attachments)` and calls `attachment_to_content()` on each attachment before passing to `chat.stream_async()`
- `pyproject.toml` installs shinychat from GitHub main until the next PyPI release ships `Attachment`/`attachment_to_content` (should be 0.5.2)

**R** (`querychat_module.R`):
- `mod_ui()` gains an `allow_attachments = TRUE` parameter forwarded to `shinychat::chat_ui()`
- `append_stream_task` uses `!!!user_input` so both plain character strings (no attachments) and lists of ellmer `Content` objects (with attachments) splice correctly into `stream_async()`

## Opt-out

Users who need to disable attachments can pass the flag through the existing `**kwargs` / `...` passthrough:

```python
qc.ui(allow_attachments=False)       # Python
qc.sidebar(allow_attachments=False)  # Python
```
```r
qc$ui(allow_attachments = FALSE)       # R
qc$sidebar(allow_attachments = FALSE)  # R
```

## Follow-up

Once shinychat 0.5.2 ships to PyPI, bump `pyproject.toml` from the git source back to `"shinychat>=0.5.2"`.