### PR TITLE
fix: exclude control inputs from Shiny bookmarking

### DIFF
--- a/pkg-py/src/querychat/_shiny.py
+++ b/pkg-py/src/querychat/_shiny.py
@@ -300,6 +300,8 @@ class QueryChat(QueryChatBase[IntoFrameT]):
             )
 
         def app_server(input: Inputs, output: Outputs, session: Session):
+            if enable_bookmarking:
+                session.bookmark.exclude.append("reset_query")
             vals = mod_server(
                 self.id,
                 data_source=data_source,

--- a/pkg-py/src/querychat/_shiny_module.py
+++ b/pkg-py/src/querychat/_shiny_module.py
@@ -250,6 +250,7 @@ def mod_server(
 
     if enable_bookmarking:
         chat_ui.enable_bookmarking(chat)
+        session.bookmark.exclude.append("chat_update")
 
         @session.bookmark.on_bookmark
         def _on_bookmark(x: BookmarkState) -> None:

--- a/pkg-py/src/querychat/_viz_tools.py
+++ b/pkg-py/src/querychat/_viz_tools.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 from chatlas import ContentToolResult, Tool, content_image_url
 from htmltools import HTMLDependency, TagList, tags
 from shiny.module import resolve_id
+from shiny.session import get_current_session
 from shinychat.types import ToolResultDisplay
 
 from shiny import ui
@@ -247,6 +248,9 @@ def build_viz_footer(
     footer_id = f"querychat_footer_{uuid4().hex[:8]}"
     query_section_id = f"{footer_id}_query"
     code_editor_id = f"{footer_id}_code"
+    sess = get_current_session()
+    if sess is not None:
+        sess.root_scope().bookmark.exclude.append(code_editor_id)
 
     # Read-only code editor for query display
     code_editor = ui.input_code_editor(

--- a/pkg-r/R/QueryChat.R
+++ b/pkg-r/R/QueryChat.R
@@ -531,6 +531,7 @@ QueryChat <- R6::R6Class(
       }
 
       server <- function(input, output, session) {
+        shiny::setBookmarkExclude(c("close_btn", "reset_query"))
         # Enable bookmarking if bookmark_store is enabled
         enable_bookmarking <- bookmark_store %in% c("url", "server")
         qc_vals <- self$server(enable_bookmarking = enable_bookmarking)

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -146,6 +146,7 @@ mod_server <- function(
 
     if (enable_bookmarking) {
       shinychat::chat_restore("chat", chat, session = session)
+      shiny::setBookmarkExclude("chat_update", session = session)
 
       shiny::onBookmark(function(state) {
         state$values$querychat_sql <- current_query()

--- a/pkg-r/R/querychat_viz.R
+++ b/pkg-r/R/querychat_viz.R
@@ -138,7 +138,8 @@ visualize_result <- function(
     ggsql_str,
     title,
     widget_id,
-    dom_widget_id = session$ns(widget_id)
+    dom_widget_id = session$ns(widget_id),
+    session = session
   )
   extra <- list(
     display = list(
@@ -174,11 +175,15 @@ build_viz_footer <- function(
   ggsql_str,
   title,
   widget_id,
-  dom_widget_id
+  dom_widget_id,
+  session = NULL
 ) {
   footer_id <- paste0("querychat_footer_", random_hex())
   query_section_id <- paste0(footer_id, "_query")
   code_editor_id <- paste0(footer_id, "_code")
+  if (!is.null(session)) {
+    shiny::setBookmarkExclude(code_editor_id, session = session)
+  }
 
   code_editor <- bslib::input_code_editor(
     id = code_editor_id,


### PR DESCRIPTION
## Summary

Audited all Shiny inputs created by querychat's UI/server functions and excluded the control-only inputs that should not appear in bookmark state.

**Inputs excluded by this PR (both R and Python):**
- `chat_update` — JS event ping fired when the user clicks a query link in a chat message; not meaningful state
- `close_btn` — closes the standalone `app()` popup; not meaningful state
- `reset_query` — action button click counter; not meaningful state
- `querychat_footer_<hex>_code` — ephemeral read-only code editor displaying the ggsql query; ID is randomly generated per session and cannot be restored

**Out of scope:** `chat_user_input`, `chat_cancel`, `chat_slash_command`, and `chat_greeting_requested` are owned by shinychat and will be excluded upstream via posit-dev/shinychat#259.

In R, `chat_update` is excluded via `setBookmarkExclude()` alongside shinychat's own exclusions inside `chat_restore()`. The viz code editor uses the module `session` passed into `build_viz_footer()`. In Python, exclusions follow the same pattern as shinychat's `enable_bookmarking()`, using `session.bookmark.exclude` and `root_scope()` for the viz footer.

## Verification

Enable bookmarking on a querychat app, interact with it (run a query, click a viz query link, reset the query), then bookmark the state. The bookmark URL or server-side state should contain only `querychat_sql`, `querychat_title`, `querychat_has_greeted`, and `querychat_viz_widgets` — none of the excluded input names.