### PR TITLE
fix(prompts): Inject raw data description and extra instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ README_files/
 README.html
 .DS_Store
 test-results/
+shiny_bookmarks/
 python-package/examples/titanic.db
 .quarto
 *.db

--- a/pkg-py/CHANGELOG.md
+++ b/pkg-py/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The system prompt is now lighter: full schema is no longer embedded upfront. Instead the LLM fetches per-table schema on demand via the new `querychat_get_schema` tool — and only when it needs to. When a `DataDict` is provided, the tool skips columns that already have descriptions, so the LLM only pays for what isn't already documented. (#195)
 * The query tool result card now starts collapsed by default. Users can still expand it to see the SQL query and results. Set `QUERYCHAT_TOOL_DETAILS=expanded` to restore the previous behavior. (#239)
+* Fixed `data_description` and `extra_instructions` being HTML-escaped in the system prompt. Special characters like `<`, `>`, and `&` in developer-provided descriptions and instructions are now passed to the LLM verbatim. (#258)
 
 ## [0.6.1] - 2026-05-26
 

--- a/pkg-py/src/querychat/prompts/prompt.md
+++ b/pkg-py/src/querychat/prompts/prompt.md
@@ -14,7 +14,7 @@ You have access to a {{db_type}} SQL database with the following tables:
 {{/has_data_dicts}}
 {{#data_description}}
 <data_description>
-{{data_description}}
+{{{data_description}}}
 </data_description>
 
 {{/data_description}}

--- a/pkg-py/src/querychat/prompts/prompt.md
+++ b/pkg-py/src/querychat/prompts/prompt.md
@@ -303,5 +303,5 @@ You might want to <span class="suggestion">explore the advanced features</span> 
 {{#extra_instructions}}
 ## Additional Instructions
 
-{{extra_instructions}}
+{{{extra_instructions}}}
 {{/extra_instructions}}

--- a/pkg-r/NEWS.md
+++ b/pkg-r/NEWS.md
@@ -37,6 +37,8 @@
 
 * The system prompt is now lighter: full schema is no longer embedded upfront. Instead the LLM fetches per-table schema on demand via the new `querychat_get_schema` tool — and only when it needs to. When a `data_dict` is provided, the tool skips columns that already have descriptions, so the LLM only pays for what isn't already documented. (#195)
 
+* Fixed `data_description` and `extra_instructions` being HTML-escaped in the system prompt. Special characters like `<`, `>`, and `&` in developer-provided descriptions and instructions are now passed to the LLM verbatim. (#258)
+
 # querychat 0.3.0
 
 ## New features

--- a/pkg-r/inst/prompts/prompt.md
+++ b/pkg-r/inst/prompts/prompt.md
@@ -14,7 +14,7 @@ You have access to a {{db_type}} SQL database with the following tables:
 {{/has_data_dicts}}
 {{#data_description}}
 <data_description>
-{{data_description}}
+{{{data_description}}}
 </data_description>
 
 {{/data_description}}

--- a/pkg-r/inst/prompts/prompt.md
+++ b/pkg-r/inst/prompts/prompt.md
@@ -303,5 +303,5 @@ You might want to <span class="suggestion">explore the advanced features</span> 
 {{#extra_instructions}}
 ## Additional Instructions
 
-{{extra_instructions}}
+{{{extra_instructions}}}
 {{/extra_instructions}}


### PR DESCRIPTION
## Description

The system prompt template used `{{data_description}}` and `{{extra_instructions}}`, which HTML-escapes developer-provided text via Mustache. Characters like `<`, `>`, `&`, and quotes (common in instructions referencing SQL conditions, HTML suggestion tags, or quoted column names) were corrupted before reaching the LLM.

Both values are free-form, developer-supplied prose passed through verbatim, so they should be injected raw with triple-mustache (`{{{ }}}`), matching the existing treatment of `data_dicts`, `tables_overview`, and `semantic_views`.

## Changes

- `{{data_description}}` → `{{{data_description}}}` (R + Python prompts)
- `{{extra_instructions}}` → `{{{extra_instructions}}}` (R + Python prompts)
- Add `shiny_bookmarks/` to `.gitignore`