### PR TITLE
feat: schema-aware greetings via a QueryChatGreeter API

### DIFF
--- a/pkg-py/CHANGELOG.md
+++ b/pkg-py/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-* Chat greetings now use shinychat's greeting API (requires shinychat >= 0.4.0). A provided `greeting` renders instantly when the app loads, and when no `greeting` is given one is generated on demand without being added to the conversation history. Generated greetings are now preserved across bookmark/restore. (#249)
+* Chat greetings now use shinychat's greeting API (requires shinychat >= 0.4.0). A provided `greeting` renders instantly when the app loads, and when no `greeting` is given one is generated on demand — now **schema-aware**, so it can describe the data it's about to help you explore — without being added to the conversation history. Generated greetings are preserved across bookmark/restore. Tables passed to `QueryChat()` are described in the greeting automatically; opt additional tables in with `include_in_greeting=True` on `add_table()`/`add_tables()`, or fine-tune which tables and which template the greeting uses via `qc.greeter`. (#249, #261)
 
 * The system prompt is now lighter: full schema is no longer embedded upfront. Instead the LLM fetches per-table schema on demand via the new `querychat_get_schema` tool — and only when it needs to. When a `DataDict` is provided, the tool skips columns that already have descriptions, so the LLM only pays for what isn't already documented. (#195)
 * The query tool result card now starts collapsed by default. Users can still expand it to see the SQL query and results. Set `QUERYCHAT_TOOL_DETAILS=expanded` to restore the previous behavior. (#239)

--- a/pkg-py/docs/greet.qmd
+++ b/pkg-py/docs/greet.qmd
@@ -74,3 +74,37 @@ qc = QueryChat(
 )
 app = qc.app()
 ```
+
+### Greetings with multiple tables
+
+The generated greeting is *schema-aware*: querychat shares the schema of the
+relevant tables with the model so the opening message can describe the data
+it's about to help you explore. Tables passed to `QueryChat()` are included in
+the greeting automatically.
+
+Tables added later with `add_table()` or `add_tables()` are **not** included by
+default — pass `include_in_greeting=True` to opt them in:
+
+```python
+qc = QueryChat(orders, "orders")              # included automatically
+qc.add_table(customers, "customers")          # not included by default
+qc.add_table(products, "products", include_in_greeting=True)  # opted in
+
+qc.greeter.tables
+#> ['orders', 'products']
+```
+
+For `add_tables()`, `include_in_greeting` can also be a list of names
+selecting which of the added tables to include:
+
+```python
+qc.add_tables(engine, include_in_greeting=["orders", "customers"])
+```
+
+You can also set the included tables directly, or swap in a custom greeting
+template, through `qc.greeter`:
+
+```python
+qc.greeter.tables = ["orders", "customers"]
+qc.greeter.prompt = "my-greeting-template.md"
+```

--- a/pkg-py/src/querychat/_dash.py
+++ b/pkg-py/src/querychat/_dash.py
@@ -298,6 +298,7 @@ class QueryChat(StateDictQueryChat[IntoFrameT]):
             client_factory=self._client_factory,
             greeting=self.greeting,
             query_executor=self._require_query_executor("ui"),
+            greeting_client_factory=self._build_greeting_client,
         )
 
         return html.Div(
@@ -569,7 +570,9 @@ def register_chat_callbacks(
 
         if not state.initialize_greeting_if_preset():
             greeting = ""
-            async for chunk in stream_response_async(state.client, GREETING_PROMPT):
+            async for chunk in stream_response_async(
+                state.build_greeting_client(), GREETING_PROMPT
+            ):
                 greeting += chunk
             state.set_greeting(greeting)
 

--- a/pkg-py/src/querychat/_dash.py
+++ b/pkg-py/src/querychat/_dash.py
@@ -298,7 +298,7 @@ class QueryChat(StateDictQueryChat[IntoFrameT]):
             client_factory=self._client_factory,
             greeting=self.greeting,
             query_executor=self._require_query_executor("ui"),
-            greeting_client_factory=self._build_greeting_client,
+            greeting_client_factory=self.greeter.build_client,
         )
 
         return html.Div(

--- a/pkg-py/src/querychat/_data_dict.py
+++ b/pkg-py/src/querychat/_data_dict.py
@@ -223,7 +223,9 @@ class DataDict(BaseModel):
                 undocumented.append(meta)
 
         if undocumented:
-            executor.populate_column_stats(table_name, undocumented, categorical_threshold)
+            executor.populate_column_stats(
+                table_name, undocumented, categorical_threshold
+            )
 
         return metas
 

--- a/pkg-py/src/querychat/_datasource.py
+++ b/pkg-py/src/querychat/_datasource.py
@@ -75,7 +75,11 @@ def format_schema(table_name: str, columns: list[ColumnMeta]) -> str:
             lines.append(f"  Description: {col.description}")
         if col.constraints:
             lines.append(f"  Constraints: {', '.join(col.constraints)}")
-        if col.kind in ("numeric", "date") and col.min_val is not None and col.max_val is not None:
+        if (
+            col.kind in ("numeric", "date")
+            and col.min_val is not None
+            and col.max_val is not None
+        ):
             lines.append(f"  Range: {col.min_val} to {col.max_val}")
         elif col.categories:
             cats = ", ".join(f"'{v}'" for v in col.categories)
@@ -127,9 +131,7 @@ def duckdb_column_stats(
             select_parts.append(f'MIN({quoted}) as "{col.name}__min"')
             select_parts.append(f'MAX({quoted}) as "{col.name}__max"')
         elif col.kind == "text":
-            select_parts.append(
-                f'COUNT(DISTINCT {quoted}) as "{col.name}__nunique"'
-            )
+            select_parts.append(f'COUNT(DISTINCT {quoted}) as "{col.name}__nunique"')
 
     if not select_parts:
         return
@@ -166,7 +168,6 @@ def duckdb_column_stats(
             col.categories = [str(row[0]) for row in cat_result]
     except Exception:  # noqa: S110
         pass
-
 
 
 def duckdb_lock_down(conn: duckdb.DuckDBPyConnection) -> None:
@@ -610,7 +611,9 @@ class SQLAlchemySource(DataSource[nw.DataFrame]):
         """Create ColumnMeta from SQLAlchemy type."""
         kind: Literal["numeric", "text", "date", "other"]
 
-        if isinstance(sa_type, (sqltypes.Integer, sqltypes.BigInteger, sqltypes.SmallInteger)):
+        if isinstance(
+            sa_type, (sqltypes.Integer, sqltypes.BigInteger, sqltypes.SmallInteger)
+        ):
             kind = "numeric"
             sql_type = "INTEGER"
         elif isinstance(sa_type, sqltypes.Float):
@@ -653,7 +656,9 @@ class SQLAlchemySource(DataSource[nw.DataFrame]):
                 select_parts.append(f"MIN({col.name}) as {col.name}__min")
                 select_parts.append(f"MAX({col.name}) as {col.name}__max")
             elif col.kind == "text":
-                select_parts.append(f"COUNT(DISTINCT {col.name}) as {col.name}__nunique")
+                select_parts.append(
+                    f"COUNT(DISTINCT {col.name}) as {col.name}__nunique"
+                )
 
         if not select_parts:
             return
@@ -661,7 +666,9 @@ class SQLAlchemySource(DataSource[nw.DataFrame]):
         # Execute stats query
         stats = {}
         try:
-            stats_query = text(f"SELECT {', '.join(select_parts)} FROM {self.table_name}")
+            stats_query = text(
+                f"SELECT {', '.join(select_parts)} FROM {self.table_name}"
+            )
             with self._get_connection() as conn:
                 result = conn.execute(stats_query).fetchone()
                 if result:
@@ -677,7 +684,8 @@ class SQLAlchemySource(DataSource[nw.DataFrame]):
 
         # Find text columns that qualify as categorical
         categorical_cols = [
-            col for col in columns
+            col
+            for col in columns
             if col.kind == "text"
             and (nunique := stats.get(f"{col.name}__nunique"))
             and nunique <= categorical_threshold
@@ -871,7 +879,9 @@ class PolarsLazySource(DataSource["pl.LazyFrame"]):
         return format_schema(self.table_name, metas)
 
     def get_column_metas(self) -> list[ColumnMeta]:
-        return [self._make_column_meta(name, dtype) for name, dtype in self._schema.items()]
+        return [
+            self._make_column_meta(name, dtype) for name, dtype in self._schema.items()
+        ]
 
     def populate_column_stats(
         self, columns: list[ColumnMeta], categorical_threshold: int
@@ -1014,7 +1024,8 @@ class PolarsLazySource(DataSource["pl.LazyFrame"]):
 
         # Find text columns that qualify as categorical
         categorical_cols = [
-            col for col in columns
+            col
+            for col in columns
             if col.kind == "text"
             and (nunique := stats.get(f"{col.name}__nunique"))
             and nunique <= categorical_threshold
@@ -1156,7 +1167,8 @@ class IbisSource(DataSource["ibis.Table"]):
                 col.max_val = stats.get(f"{col.name}__max")
 
         categorical_cols = [
-            col for col in columns
+            col
+            for col in columns
             if col.kind == "text"
             and (nunique := stats.get(f"{col.name}__nunique"))
             and nunique <= categorical_threshold

--- a/pkg-py/src/querychat/_gradio.py
+++ b/pkg-py/src/querychat/_gradio.py
@@ -288,7 +288,9 @@ class QueryChat(StateDictQueryChat[IntoFrameT]):
 
             if not state.initialize_greeting_if_preset():
                 greeting = ""
-                for chunk in stream_response(state.client, GREETING_PROMPT):
+                for chunk in stream_response(
+                    state.build_greeting_client(), GREETING_PROMPT
+                ):
                     greeting += chunk
                 state.set_greeting(greeting)
 

--- a/pkg-py/src/querychat/_pin_source.py
+++ b/pkg-py/src/querychat/_pin_source.py
@@ -29,6 +29,7 @@ def is_pins_board(obj: object) -> TypeGuard[BaseBoard]:
     except ImportError:
         return False
 
+
 DUCKDB_FILE_TYPES = {"parquet", "csv", "json"}
 DUCKDB_READER_FN = {
     "parquet": "read_parquet",
@@ -153,8 +154,7 @@ class PinSource(DataSource[nw.DataFrame]):
                 vname = f"__pin_staging_{effective_table_name}"
                 conn.register(vname, arrow_df)
                 conn.execute(
-                    f'CREATE TABLE "{effective_table_name}" AS '
-                    f'SELECT * FROM "{vname}"'
+                    f'CREATE TABLE "{effective_table_name}" AS SELECT * FROM "{vname}"'
                 )
                 conn.unregister(vname)
             else:
@@ -169,8 +169,7 @@ class PinSource(DataSource[nw.DataFrame]):
                 vname = f"__pin_staging_{effective_table_name}"
                 conn.register(vname, data)
                 conn.execute(
-                    f'CREATE TABLE "{effective_table_name}" AS '
-                    f'SELECT * FROM "{vname}"'
+                    f'CREATE TABLE "{effective_table_name}" AS SELECT * FROM "{vname}"'
                 )
                 conn.unregister(vname)
 
@@ -212,9 +211,7 @@ class PinSource(DataSource[nw.DataFrame]):
         check_query(query)
         normalized = query.rstrip().removesuffix(";")
         result = _convert_result(
-            self._conn.execute(
-                f"SELECT * FROM ({normalized}) AS subquery LIMIT 1"
-            )
+            self._conn.execute(f"SELECT * FROM ({normalized}) AS subquery LIMIT 1")
         )
 
         if require_all_columns:
@@ -232,9 +229,7 @@ class PinSource(DataSource[nw.DataFrame]):
         return result
 
     def get_data(self) -> nw.DataFrame:
-        return _convert_result(
-            self._conn.execute(f'SELECT * FROM "{self.table_name}"')
-        )
+        return _convert_result(self._conn.execute(f'SELECT * FROM "{self.table_name}"'))
 
     def cleanup(self) -> None:
         if self._conn:

--- a/pkg-py/src/querychat/_query_executor.py
+++ b/pkg-py/src/querychat/_query_executor.py
@@ -47,13 +47,17 @@ class QueryExecutor(ABC):
         self, table_name: str, columns: list[ColumnMeta], categorical_threshold: int
     ) -> None: ...
 
-    def get_column_details(self, table_name: str, categorical_threshold: int) -> list[ColumnMeta]:
+    def get_column_details(
+        self, table_name: str, categorical_threshold: int
+    ) -> list[ColumnMeta]:
         metas = self.get_column_metas(table_name)
         self.populate_column_stats(table_name, metas, categorical_threshold)
         return metas
 
     def get_schema(self, table_name: str, categorical_threshold: int) -> str:
-        return format_schema(table_name, self.get_column_details(table_name, categorical_threshold))
+        return format_schema(
+            table_name, self.get_column_details(table_name, categorical_threshold)
+        )
 
     @staticmethod
     def _validate_missing_columns(
@@ -114,7 +118,9 @@ class DuckDBExecutor(QueryExecutor):
 
         if require_all_columns:
             result_columns = {desc[0] for desc in result.description}
-            self._validate_missing_columns(result_columns, self._table_columns[table_name])
+            self._validate_missing_columns(
+                result_columns, self._table_columns[table_name]
+            )
 
     def get_db_type(self) -> str:
         return "DuckDB"
@@ -161,7 +167,9 @@ class PolarsSQLExecutor(QueryExecutor):
         if require_all_columns:
             full_lf = self._ctx.execute(query)
             result_columns = set(full_lf.collect_schema().keys())
-            self._validate_missing_columns(result_columns, self._table_columns[table_name])
+            self._validate_missing_columns(
+                result_columns, self._table_columns[table_name]
+            )
 
     def get_db_type(self) -> str:
         return "Polars"
@@ -213,7 +221,9 @@ class DataSourceExecutor(QueryExecutor):
     def populate_column_stats(
         self, table_name: str, columns: list[ColumnMeta], categorical_threshold: int
     ) -> None:
-        self._data_sources[table_name].populate_column_stats(columns, categorical_threshold)
+        self._data_sources[table_name].populate_column_stats(
+            columns, categorical_threshold
+        )
 
 
 def get_shared_dataframe_backend(sources: dict[str, DataFrameSource]) -> str:

--- a/pkg-py/src/querychat/_querychat_base.py
+++ b/pkg-py/src/querychat/_querychat_base.py
@@ -341,10 +341,16 @@ class QueryChatBase(Generic[IntoFrameT]):
         """
         tbls = [n for n in self.greeter.tables if n in self._data_sources]
         sources = {n: self._data_sources[n] for n in tbls}
-        # Only keep dicts that describe an included table, so a curated greeting
-        # subset doesn't carry dict-level prose about excluded tables.
+        # Keep a dict if it describes an included table, or if it is a global
+        # (table-less) dict carrying a dict-level description. Drop the
+        # cross-table global fields (relationships, glossary) so a curated
+        # greeting subset can't leak excluded-table prose; per-table entries are
+        # scoped to the included tables at render time.
         greeting_dicts = [
-            dd for dd in self._data_dicts if any(n in tbls for n in dd.tables)
+            dd.model_copy(update={"relationships": [], "glossary": {}})
+            for dd in self._data_dicts
+            if any(n in tbls for n in dd.tables)
+            or (not dd.tables and dd.description)
         ]
         greeting_prompt_obj = QueryChatSystemPrompt(
             prompt_template=self.greeter.prompt,

--- a/pkg-py/src/querychat/_querychat_base.py
+++ b/pkg-py/src/querychat/_querychat_base.py
@@ -934,6 +934,7 @@ class StateDictQueryChat(QueryChatBase[IntoFrameT]):
             client_factory=self._client_factory,
             greeting=self.greeting,
             query_executor=self._require_query_executor("_deserialize_state"),
+            greeting_client_factory=self._build_greeting_client,
         )
         if state_data:
             state.update_from_dict(state_data)

--- a/pkg-py/src/querychat/_querychat_base.py
+++ b/pkg-py/src/querychat/_querychat_base.py
@@ -626,8 +626,7 @@ class QueryChatBase(Generic[IntoFrameT]):
         for name in greeting_names:
             if name not in new_greeting:
                 new_greeting.append(name)
-        if new_greeting != self.greeter.tables:
-            self.greeter.tables = new_greeting
+        self.greeter.tables = new_greeting
 
     def remove_table(self, table_name: str) -> None:
         """
@@ -667,6 +666,10 @@ class QueryChatBase(Generic[IntoFrameT]):
 
         self._build_system_prompt(data_sources=next_data_sources)
         self._data_sources = next_data_sources
+        if self._greeter is not None:
+            self._greeter.tables = [
+                n for n in self._greeter.tables if n != table_name
+            ]
         if self._query_executor is not None:
             with contextlib.suppress(Exception):
                 self._query_executor.cleanup()

--- a/pkg-py/src/querychat/_querychat_base.py
+++ b/pkg-py/src/querychat/_querychat_base.py
@@ -479,7 +479,7 @@ class QueryChatBase(Generic[IntoFrameT]):
         tables: list[str] | None = None,
         *,
         replace: bool = False,
-        include_in_greeting: bool | list[str] = False,
+        include_in_greeting: bool | str | list[str] = False,
     ) -> None:
         """
         Add multiple tables from a SQLAlchemy engine or Ibis backend in a single call.
@@ -502,7 +502,8 @@ class QueryChatBase(Generic[IntoFrameT]):
             name already exists.
         include_in_greeting
             ``True`` to include all added tables in the greeting, ``False`` (default)
-            for none, or a list of table names to include.
+            for none, or a table name (or list of table names) to include. Any
+            other type raises ``TypeError``.
 
         Raises
         ------
@@ -591,12 +592,22 @@ class QueryChatBase(Generic[IntoFrameT]):
                 self._query_executor.cleanup()
             self._query_executor = None
 
-        if include_in_greeting is True:
-            greeting_names = list(tables)
-        elif include_in_greeting is False:
-            greeting_names = []
+        if isinstance(include_in_greeting, bool):
+            greeting_names = list(tables) if include_in_greeting else []
+        elif isinstance(include_in_greeting, str):
+            greeting_names = (
+                [include_in_greeting] if include_in_greeting in tables else []
+            )
+        elif isinstance(include_in_greeting, list) and all(
+            isinstance(name, str) for name in include_in_greeting
+        ):
+            greeting_names = [name for name in include_in_greeting if name in tables]
         else:
-            greeting_names = [n for n in include_in_greeting if n in tables]
+            raise TypeError(
+                "include_in_greeting must be True, False, or a table name "
+                "(or list of table names), got "
+                f"{type(include_in_greeting).__name__}."
+            )
 
         new_greeting = list(self.greeter.tables)
         for name in greeting_names:

--- a/pkg-py/src/querychat/_querychat_base.py
+++ b/pkg-py/src/querychat/_querychat_base.py
@@ -422,6 +422,8 @@ class QueryChatBase(Generic[IntoFrameT]):
 
         Raises
         ------
+        TypeError
+            If include_in_greeting is not a bool.
         ValueError
             If table_name already exists (and replace=False) or is invalid.
         RuntimeError
@@ -432,6 +434,12 @@ class QueryChatBase(Generic[IntoFrameT]):
             raise RuntimeError(
                 "Cannot add tables after server initialization. "
                 "Add all tables before calling .server() or .app()."
+            )
+
+        if not isinstance(include_in_greeting, bool):
+            raise TypeError(
+                "include_in_greeting must be True or False, got "
+                f"{type(include_in_greeting).__name__}."
             )
 
         if not is_pins_board(data_source) and not re.match(

--- a/pkg-py/src/querychat/_querychat_base.py
+++ b/pkg-py/src/querychat/_querychat_base.py
@@ -320,50 +320,37 @@ class QueryChatBase(Generic[IntoFrameT]):
     def generate_greeting(self, *, echo: Literal["none", "output"] = "none") -> str:
         """Generate a welcome greeting for the chat."""
         self._require_initialized("generate_greeting")
-        return self.greeter.generate(echo=echo)
+        greeting = self.greeter.generate(echo=echo)
+        self.greeting = greeting
+        return greeting
 
     @property
     def greeter(self) -> QueryChatGreeter:
         """Greeting configuration and generator for this QueryChat instance."""
         if self._greeter is None:
-            self._greeter = QueryChatGreeter(self)
+
+            def client_factory(
+                tables: list[str],
+                prompt: str | Path,
+                base: str | chatlas.Chat | None = None,
+            ) -> chatlas.Chat:
+                sp = QueryChatSystemPrompt(
+                    prompt_template=prompt,
+                    data_sources=self._data_sources,
+                    data_description=self._data_description,
+                    extra_instructions=None,
+                    categorical_threshold=self._categorical_threshold,
+                    data_dicts=self._data_dicts,
+                    include_tables=tables or False,
+                    include_relationships=False,
+                    include_glossary=False,
+                )
+                chat = create_client(base if base is not None else self._client_spec)
+                chat.system_prompt = sp.render(None)
+                return chat
+
+            self._greeter = QueryChatGreeter(client_factory)
         return self._greeter
-
-    def _build_greeting_client(
-        self, client_spec: str | chatlas.Chat | None = None
-    ) -> chatlas.Chat:
-        """
-        Build a fresh chat client configured with the greeting system prompt.
-
-        ``client_spec`` overrides the instance client spec so the greeting is
-        generated with the same provider/model as the session client (for
-        example, when ``server(client=...)`` overrides it).
-        """
-        tbls = [n for n in self.greeter.tables if n in self._data_sources]
-        sources = {n: self._data_sources[n] for n in tbls}
-        # Keep a dict if it describes an included table, or if it is a global
-        # (table-less) dict carrying a dict-level description. Drop the
-        # cross-table global fields (relationships, glossary) so a curated
-        # greeting subset can't leak excluded-table prose; per-table entries are
-        # scoped to the included tables at render time.
-        greeting_dicts = [
-            dd.model_copy(update={"relationships": [], "glossary": {}})
-            for dd in self._data_dicts
-            if any(n in tbls for n in dd.tables)
-            or (not dd.tables and dd.description)
-        ]
-        greeting_prompt_obj = QueryChatSystemPrompt(
-            prompt_template=self.greeter.prompt,
-            data_sources=sources,
-            data_description=self._data_description,
-            extra_instructions=None,
-            categorical_threshold=self._categorical_threshold,
-            data_dicts=greeting_dicts,
-        )
-        chat = create_client(client_spec or self._client_spec)
-        chat.set_turns([])
-        chat.system_prompt = greeting_prompt_obj.render(None)
-        return chat
 
     def console(
         self,
@@ -676,9 +663,7 @@ class QueryChatBase(Generic[IntoFrameT]):
         self._build_system_prompt(data_sources=next_data_sources)
         self._data_sources = next_data_sources
         if self._greeter is not None:
-            self._greeter.tables = [
-                n for n in self._greeter.tables if n != table_name
-            ]
+            self._greeter.tables = [n for n in self._greeter.tables if n != table_name]
         if self._query_executor is not None:
             with contextlib.suppress(Exception):
                 self._query_executor.cleanup()
@@ -970,7 +955,7 @@ class StateDictQueryChat(QueryChatBase[IntoFrameT]):
             client_factory=self._client_factory,
             greeting=self.greeting,
             query_executor=self._require_query_executor("_deserialize_state"),
-            greeting_client_factory=self._build_greeting_client,
+            greeting_client_factory=self.greeter.build_client,
         )
         if state_data:
             state.update_from_dict(state_data)

--- a/pkg-py/src/querychat/_querychat_base.py
+++ b/pkg-py/src/querychat/_querychat_base.py
@@ -140,8 +140,7 @@ class QueryChatBase(Generic[IntoFrameT]):
             raise RuntimeError("Cannot build system prompt without data_source")
 
         client_has_history = (
-            self._base_client is not None
-            and bool(self._base_client.get_turns())
+            self._base_client is not None and bool(self._base_client.get_turns())
         ) or (
             self._client_console is not None and bool(self._client_console.get_turns())
         )

--- a/pkg-py/src/querychat/_querychat_base.py
+++ b/pkg-py/src/querychat/_querychat_base.py
@@ -110,7 +110,9 @@ class QueryChatBase(Generic[IntoFrameT]):
         self._extra_instructions = extra_instructions
         self._categorical_threshold = categorical_threshold
 
-        self._client_spec: str | chatlas.Chat | None = client
+        self._base_client: chatlas.Chat | None = (
+            resolve_client(client) if client is not None else None
+        )
         self._client_console = None
 
         self._system_prompt: QueryChatSystemPrompt | None = None
@@ -138,8 +140,8 @@ class QueryChatBase(Generic[IntoFrameT]):
             raise RuntimeError("Cannot build system prompt without data_source")
 
         client_has_history = (
-            isinstance(self._client_spec, chatlas.Chat)
-            and bool(self._client_spec.get_turns())
+            self._base_client is not None
+            and bool(self._base_client.get_turns())
         ) or (
             self._client_console is not None and bool(self._client_console.get_turns())
         )
@@ -213,20 +215,25 @@ class QueryChatBase(Generic[IntoFrameT]):
             self._query_executor = self._build_query_executor()
         return self._query_executor
 
+    def _create_client(self, base: chatlas.Chat | None = None) -> chatlas.Chat:
+        """Clone a Chat from ``base`` or the resolved ``_base_client``."""
+        if base is None:
+            if self._base_client is None:
+                self._base_client = resolve_client(None)
+            base = self._base_client
+        return create_client(base)
+
     def _create_session_client(
         self,
         *,
-        client_spec: str | chatlas.Chat | None | MISSING_TYPE = MISSING,
+        base: chatlas.Chat | None = None,
         tools: TOOL_GROUPS | tuple[TOOL_GROUPS, ...] | None | MISSING_TYPE = MISSING,
         update_dashboard: Callable[[UpdateDashboardData], None] | None = None,
         reset_dashboard: ResetDashboardCallback | None = None,
         visualize: Callable[[VisualizeData], None] | None = None,
     ) -> chatlas.Chat:
         """Create a fresh, fully-configured Chat."""
-        spec = (
-            self._client_spec if isinstance(client_spec, MISSING_TYPE) else client_spec
-        )
-        chat = create_client(spec)
+        chat = self._create_client(base)
 
         resolved_tools = normalize_tools(tools, default=self.tools)
 
@@ -332,7 +339,7 @@ class QueryChatBase(Generic[IntoFrameT]):
             def client_factory(
                 tables: list[str],
                 prompt: str | Path,
-                base: str | chatlas.Chat | None = None,
+                base: chatlas.Chat | None = None,
             ) -> chatlas.Chat:
                 sp = QueryChatSystemPrompt(
                     prompt_template=prompt,
@@ -345,7 +352,7 @@ class QueryChatBase(Generic[IntoFrameT]):
                     include_relationships=False,
                     include_glossary=False,
                 )
-                chat = create_client(base if base is not None else self._client_spec)
+                chat = self._create_client(base)
                 chat.system_prompt = sp.render(None)
                 return chat
 
@@ -744,19 +751,23 @@ def cleanup_failed_staged_source(
         normalized_source.cleanup()
 
 
-def create_client(client: str | chatlas.Chat | None) -> chatlas.Chat:
-    """Resolve a client spec into a fresh Chat with no conversation history."""
+def resolve_client(client: str | chatlas.Chat | None) -> chatlas.Chat:
+    """Resolve a client spec into a Chat object without cloning."""
     if client is None:
         client = os.getenv("QUERYCHAT_CLIENT", None)
 
     if client is None:
         client = "openai"
 
-    if isinstance(client, chatlas.Chat):
-        chat = copy.deepcopy(client)
-    else:
-        chat = chatlas.ChatAuto(provider_model=client)
+    if isinstance(client, str):
+        return chatlas.ChatAuto(provider_model=client)
 
+    return client
+
+
+def create_client(client: chatlas.Chat) -> chatlas.Chat:
+    """Clone a resolved Chat with empty conversation history."""
+    chat = copy.deepcopy(client)
     chat.set_turns([])
     return chat
 

--- a/pkg-py/src/querychat/_querychat_base.py
+++ b/pkg-py/src/querychat/_querychat_base.py
@@ -32,12 +32,12 @@ from ._query_executor import (
     validate_source_group_compatibility,
 )
 from ._querychat_core import (
-    GREETING_PROMPT,
     AppState,
     AppStateDict,
     create_app_state,
     warn_multi_table_flat_accessor,
 )
+from ._querychat_greeter import QueryChatGreeter
 from ._system_prompt import QueryChatSystemPrompt
 from ._utils import MISSING, MISSING_TYPE, is_ibis_backend, is_ibis_table
 from ._viz_utils import has_viz_deps, has_viz_tool
@@ -114,6 +114,7 @@ class QueryChatBase(Generic[IntoFrameT]):
         self._client_console = None
 
         self._system_prompt: QueryChatSystemPrompt | None = None
+        self._greeter: QueryChatGreeter | None = None
 
         if data_source is not None:
             if table_name is None:
@@ -123,7 +124,7 @@ class QueryChatBase(Generic[IntoFrameT]):
                     raise ValueError(
                         "table_name is required when data_source is provided"
                     )
-            self.add_table(data_source, table_name)
+            self.add_table(data_source, table_name, include_in_greeting=True)
 
     def _build_system_prompt(
         self,
@@ -319,10 +320,31 @@ class QueryChatBase(Generic[IntoFrameT]):
     def generate_greeting(self, *, echo: Literal["none", "output"] = "none") -> str:
         """Generate a welcome greeting for the chat."""
         self._require_initialized("generate_greeting")
+        return self.greeter.generate(echo=echo)
+
+    @property
+    def greeter(self) -> QueryChatGreeter:
+        """Greeting configuration and generator for this QueryChat instance."""
+        if self._greeter is None:
+            self._greeter = QueryChatGreeter(self)
+        return self._greeter
+
+    def _build_greeting_client(self) -> chatlas.Chat:
+        """Build a fresh chat client configured with the greeting system prompt."""
+        tbls = [n for n in self.greeter.tables if n in self._data_sources]
+        sources = {n: self._data_sources[n] for n in tbls}
+        greeting_prompt_obj = QueryChatSystemPrompt(
+            prompt_template=self.greeter.prompt,
+            data_sources=sources,
+            data_description=self._data_description,
+            extra_instructions=None,
+            categorical_threshold=self._categorical_threshold,
+            data_dicts=self._data_dicts,
+        )
         chat = create_client(self._client_spec)
-        if self._system_prompt is not None:
-            chat.system_prompt = self._system_prompt.render(self.tools)
-        return str(chat.chat(GREETING_PROMPT, echo=echo))
+        chat.set_turns([])
+        chat.system_prompt = greeting_prompt_obj.render(None)
+        return chat
 
     def console(
         self,
@@ -381,6 +403,7 @@ class QueryChatBase(Generic[IntoFrameT]):
         table_name: str,
         *,
         replace: bool = False,
+        include_in_greeting: bool = False,
     ) -> None:
         """
         Add or replace a table in the QueryChat instance.
@@ -394,6 +417,8 @@ class QueryChatBase(Generic[IntoFrameT]):
         replace
             If True, replace an existing table with the same name.
             If False (default), raise ValueError if the table already exists.
+        include_in_greeting
+            If True, include this table's schema in the greeting system prompt.
 
         Raises
         ------
@@ -445,12 +470,16 @@ class QueryChatBase(Generic[IntoFrameT]):
                 self._query_executor.cleanup()
             self._query_executor = None
 
+        if include_in_greeting and table_name not in self.greeter.tables:
+            self.greeter.tables = [*self.greeter.tables, table_name]
+
     def add_tables(  # noqa: PLR0912
         self,
         data_source: sqlalchemy.Engine | SQLBackend,
         tables: list[str] | None = None,
         *,
         replace: bool = False,
+        include_in_greeting: bool | list[str] = False,
     ) -> None:
         """
         Add multiple tables from a SQLAlchemy engine or Ibis backend in a single call.
@@ -471,6 +500,9 @@ class QueryChatBase(Generic[IntoFrameT]):
             If ``True``, replace any existing table whose name appears in
             ``tables``. If ``False`` (default), raise ``ValueError`` if any
             name already exists.
+        include_in_greeting
+            ``True`` to include all added tables in the greeting, ``False`` (default)
+            for none, or a list of table names to include.
 
         Raises
         ------
@@ -558,6 +590,20 @@ class QueryChatBase(Generic[IntoFrameT]):
             with contextlib.suppress(Exception):
                 self._query_executor.cleanup()
             self._query_executor = None
+
+        if include_in_greeting is True:
+            greeting_names = list(tables)
+        elif include_in_greeting is False:
+            greeting_names = []
+        else:
+            greeting_names = [n for n in include_in_greeting if n in tables]
+
+        new_greeting = list(self.greeter.tables)
+        for name in greeting_names:
+            if name not in new_greeting:
+                new_greeting.append(name)
+        if new_greeting != self.greeter.tables:
+            self.greeter.tables = new_greeting
 
     def remove_table(self, table_name: str) -> None:
         """

--- a/pkg-py/src/querychat/_querychat_base.py
+++ b/pkg-py/src/querychat/_querychat_base.py
@@ -506,7 +506,7 @@ class QueryChatBase(Generic[IntoFrameT]):
         tables: list[str] | None = None,
         *,
         replace: bool = False,
-        include_in_greeting: bool | str | list[str] = False,
+        include_in_greeting: bool | list[str] = False,
     ) -> None:
         """
         Add multiple tables from a SQLAlchemy engine or Ibis backend in a single call.
@@ -529,8 +529,8 @@ class QueryChatBase(Generic[IntoFrameT]):
             name already exists.
         include_in_greeting
             ``True`` to include all added tables in the greeting, ``False`` (default)
-            for none, or a table name (or list of table names) to include. Any
-            other type raises ``TypeError``.
+            for none, or a list of table names to include. Any other type raises
+            ``TypeError``.
 
         Raises
         ------
@@ -599,19 +599,14 @@ class QueryChatBase(Generic[IntoFrameT]):
 
         if isinstance(include_in_greeting, bool):
             greeting_names = list(tables) if include_in_greeting else []
-        elif isinstance(include_in_greeting, str):
-            greeting_names = (
-                [include_in_greeting] if include_in_greeting in tables else []
-            )
         elif isinstance(include_in_greeting, list) and all(
             isinstance(name, str) for name in include_in_greeting
         ):
             greeting_names = [name for name in include_in_greeting if name in tables]
         else:
             raise TypeError(
-                "include_in_greeting must be True, False, or a table name "
-                "(or list of table names), got "
-                f"{type(include_in_greeting).__name__}."
+                "include_in_greeting must be True, False, or a list of table "
+                f"names, got {type(include_in_greeting).__name__}."
             )
 
         normalized = {name: normalized_builder(name) for name in tables}

--- a/pkg-py/src/querychat/_querychat_base.py
+++ b/pkg-py/src/querychat/_querychat_base.py
@@ -333,13 +333,18 @@ class QueryChatBase(Generic[IntoFrameT]):
         """Build a fresh chat client configured with the greeting system prompt."""
         tbls = [n for n in self.greeter.tables if n in self._data_sources]
         sources = {n: self._data_sources[n] for n in tbls}
+        # Only keep dicts that describe an included table, so a curated greeting
+        # subset doesn't carry dict-level prose about excluded tables.
+        greeting_dicts = [
+            dd for dd in self._data_dicts if any(n in tbls for n in dd.tables)
+        ]
         greeting_prompt_obj = QueryChatSystemPrompt(
             prompt_template=self.greeter.prompt,
             data_sources=sources,
             data_description=self._data_description,
             extra_instructions=None,
             categorical_threshold=self._categorical_threshold,
-            data_dicts=self._data_dicts,
+            data_dicts=greeting_dicts,
         )
         chat = create_client(self._client_spec)
         chat.set_turns([])

--- a/pkg-py/src/querychat/_querychat_base.py
+++ b/pkg-py/src/querychat/_querychat_base.py
@@ -329,8 +329,16 @@ class QueryChatBase(Generic[IntoFrameT]):
             self._greeter = QueryChatGreeter(self)
         return self._greeter
 
-    def _build_greeting_client(self) -> chatlas.Chat:
-        """Build a fresh chat client configured with the greeting system prompt."""
+    def _build_greeting_client(
+        self, client_spec: str | chatlas.Chat | None = None
+    ) -> chatlas.Chat:
+        """
+        Build a fresh chat client configured with the greeting system prompt.
+
+        ``client_spec`` overrides the instance client spec so the greeting is
+        generated with the same provider/model as the session client (for
+        example, when ``server(client=...)`` overrides it).
+        """
         tbls = [n for n in self.greeter.tables if n in self._data_sources]
         sources = {n: self._data_sources[n] for n in tbls}
         # Only keep dicts that describe an included table, so a curated greeting
@@ -346,7 +354,7 @@ class QueryChatBase(Generic[IntoFrameT]):
             categorical_threshold=self._categorical_threshold,
             data_dicts=greeting_dicts,
         )
-        chat = create_client(self._client_spec)
+        chat = create_client(client_spec or self._client_spec)
         chat.set_turns([])
         chat.system_prompt = greeting_prompt_obj.render(None)
         return chat
@@ -583,6 +591,23 @@ class QueryChatBase(Generic[IntoFrameT]):
             if table_name in self._data_sources and not replace:
                 raise ValueError(f"Table '{table_name}' already exists")
 
+        if isinstance(include_in_greeting, bool):
+            greeting_names = list(tables) if include_in_greeting else []
+        elif isinstance(include_in_greeting, str):
+            greeting_names = (
+                [include_in_greeting] if include_in_greeting in tables else []
+            )
+        elif isinstance(include_in_greeting, list) and all(
+            isinstance(name, str) for name in include_in_greeting
+        ):
+            greeting_names = [name for name in include_in_greeting if name in tables]
+        else:
+            raise TypeError(
+                "include_in_greeting must be True, False, or a table name "
+                "(or list of table names), got "
+                f"{type(include_in_greeting).__name__}."
+            )
+
         normalized = {name: normalized_builder(name) for name in tables}
 
         staged: dict[str, DataSource] = {}
@@ -604,23 +629,6 @@ class QueryChatBase(Generic[IntoFrameT]):
             with contextlib.suppress(Exception):
                 self._query_executor.cleanup()
             self._query_executor = None
-
-        if isinstance(include_in_greeting, bool):
-            greeting_names = list(tables) if include_in_greeting else []
-        elif isinstance(include_in_greeting, str):
-            greeting_names = (
-                [include_in_greeting] if include_in_greeting in tables else []
-            )
-        elif isinstance(include_in_greeting, list) and all(
-            isinstance(name, str) for name in include_in_greeting
-        ):
-            greeting_names = [name for name in include_in_greeting if name in tables]
-        else:
-            raise TypeError(
-                "include_in_greeting must be True, False, or a table name "
-                "(or list of table names), got "
-                f"{type(include_in_greeting).__name__}."
-            )
 
         new_greeting = list(self.greeter.tables)
         for name in greeting_names:

--- a/pkg-py/src/querychat/_querychat_core.py
+++ b/pkg-py/src/querychat/_querychat_core.py
@@ -143,6 +143,7 @@ class AppState:
     client: Chat
     query_executor: QueryExecutor | None = None
     greeting: Optional[str] = None
+    greeting_client_factory: Optional[Callable[[], Chat]] = None
 
     active_table: str | None = None
     # sql, title, error are per-table properties backed by _table_states
@@ -266,6 +267,15 @@ class AppState:
             return True
         return False
 
+    def build_greeting_client(self) -> Chat:
+        """Build a fresh chat client configured with the greeting system prompt."""
+        if self.greeting_client_factory is None:
+            raise RuntimeError(
+                "greeting_client_factory is not set on this AppState. "
+                "Pass greeting_client_factory to create_app_state()."
+            )
+        return self.greeting_client_factory()
+
     def to_dict(self) -> AppStateDict:
         """Serialize state to dict for framework state stores."""
         return {
@@ -312,6 +322,7 @@ def create_app_state(
     client_factory: ClientFactory,
     greeting: Optional[str] = None,
     query_executor: QueryExecutor | None = None,
+    greeting_client_factory: Optional[Callable[[], Chat]] = None,
 ) -> AppState:
     """Create AppState with callbacks connected via holder pattern."""
     state_holder: dict[str, AppState | None] = {"state": None}
@@ -334,6 +345,7 @@ def create_app_state(
         client=client,
         query_executor=query_executor,
         greeting=greeting,
+        greeting_client_factory=greeting_client_factory,
     )
     state_holder["state"] = state
     return state

--- a/pkg-py/src/querychat/_querychat_core.py
+++ b/pkg-py/src/querychat/_querychat_core.py
@@ -108,8 +108,6 @@ def format_tool_result(result: ContentToolResult) -> str:
     return ""
 
 
-
-
 def format_query_error(e: Exception) -> str:
     """Format a query error with helpful guidance."""
     error_msg = str(e).lower()
@@ -245,9 +243,6 @@ class AppState:
 
             if text_parts:
                 text = "\n\n".join(text_parts)
-                # Skip the greeting prompt - it's an internal message
-                if turn.role == "user" and text == GREETING_PROMPT:
-                    continue
                 messages.append({"role": turn.role, "content": text})
 
         return messages

--- a/pkg-py/src/querychat/_querychat_core.py
+++ b/pkg-py/src/querychat/_querychat_core.py
@@ -244,6 +244,12 @@ class AppState:
 
             if text_parts:
                 text = "\n\n".join(text_parts)
+                # Hide the synthetic greeting prompt that older releases injected
+                # as a user turn onto the shared client. New sessions generate
+                # greetings on a separate client and never create this turn, but
+                # state serialized by such releases still restores it verbatim.
+                if turn.role == "user" and text == GREETING_PROMPT:
+                    continue
                 messages.append({"role": turn.role, "content": text})
 
         return messages

--- a/pkg-py/src/querychat/_querychat_greeter.py
+++ b/pkg-py/src/querychat/_querychat_greeter.py
@@ -1,0 +1,45 @@
+"""Greeting generation for QueryChat instances."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from ._querychat_core import GREETING_PROMPT
+
+if TYPE_CHECKING:
+    from ._querychat_base import QueryChatBase
+
+
+class QueryChatGreeter:
+    """Controls greeting generation for a QueryChat instance. Access via ``qc.greeter``."""
+
+    def __init__(self, parent: QueryChatBase) -> None:
+        self._parent = parent
+        self._tables: list[str] = []
+        self._prompt: str | Path = Path(__file__).parent / "prompts" / "greeting.md"
+
+    @property
+    def tables(self) -> list[str]:
+        """Table names whose context to include in the greeting."""
+        return self._tables
+
+    @tables.setter
+    def tables(self, value: list[str]) -> None:
+        self._tables = value
+
+    @property
+    def prompt(self) -> str | Path:
+        """The greeting template (string or file path)."""
+        return self._prompt
+
+    @prompt.setter
+    def prompt(self, value: str | Path) -> None:
+        self._prompt = value
+
+    def generate(self, *, echo: Literal["none", "output"] = "none") -> str:
+        """Generate a greeting using the greeting system prompt."""
+        chat = self._parent._build_greeting_client()
+        txt = str(chat.chat(GREETING_PROMPT, echo=echo))
+        self._parent.greeting = txt
+        return txt

--- a/pkg-py/src/querychat/_querychat_greeter.py
+++ b/pkg-py/src/querychat/_querychat_greeter.py
@@ -75,7 +75,7 @@ class QueryChatGreeter:
 
         client = self.build_client(base)
         stream = await client.stream_async(GREETING_PROMPT, echo="none")
-        await chat_ui.set_greeting(shinychat.chat_greeting(stream, dismissible=False))
+        await chat_ui.set_greeting(shinychat.chat_greeting(stream, persistent=True, dismissible=False))  # pyright: ignore[reportArgumentType]
         last_turn = client.get_last_turn(role="assistant")
         if last_turn is not None:
             current_greeting.set(last_turn.text)

--- a/pkg-py/src/querychat/_querychat_greeter.py
+++ b/pkg-py/src/querychat/_querychat_greeter.py
@@ -26,6 +26,18 @@ class QueryChatGreeter:
 
     @tables.setter
     def tables(self, value: list[str]) -> None:
+        if isinstance(value, str):
+            raise TypeError(
+                "greeter.tables must be a list of table names, not a single "
+                f"string. Did you mean [{value!r}]?"
+            )
+        if not isinstance(value, list) or not all(
+            isinstance(name, str) for name in value
+        ):
+            raise TypeError(
+                "greeter.tables must be a list of table names, got "
+                f"{type(value).__name__}."
+            )
         self._tables = value
 
     @property

--- a/pkg-py/src/querychat/_querychat_greeter.py
+++ b/pkg-py/src/querychat/_querychat_greeter.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     import chatlas
+
     from shiny import reactive
 
 
@@ -57,7 +58,10 @@ class QueryChatGreeter:
         return self._client_factory(self._tables, self._prompt, base)
 
     def generate(
-        self, *, echo: Literal["none", "output"] = "none", base: chatlas.Chat | None = None
+        self,
+        *,
+        echo: Literal["none", "output"] = "none",
+        base: chatlas.Chat | None = None,
     ) -> str:
         """Generate a greeting using the greeting system prompt."""
         return str(self.build_client(base).chat(GREETING_PROMPT, echo=echo))

--- a/pkg-py/src/querychat/_querychat_greeter.py
+++ b/pkg-py/src/querychat/_querychat_greeter.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     import chatlas
-
     from shiny import reactive
 
 
@@ -71,11 +70,11 @@ class QueryChatGreeter:
         base: chatlas.Chat | None = None,
     ) -> None:
         """Stream a greeting into the Shiny chat UI and capture the result."""
-        import shinychat
-
         client = self.build_client(base)
         stream = await client.stream_async(GREETING_PROMPT, echo="none")
-        await chat_ui.set_greeting(shinychat.chat_greeting(stream, persistent=True, dismissible=False))  # pyright: ignore[reportArgumentType]
+        from ._utils_shinychat import chat_greeting_persistent
+
+        await chat_ui.set_greeting(chat_greeting_persistent(stream))  # pyright: ignore[reportArgumentType]
         last_turn = client.get_last_turn(role="assistant")
         if last_turn is not None:
             current_greeting.set(last_turn.text)

--- a/pkg-py/src/querychat/_querychat_greeter.py
+++ b/pkg-py/src/querychat/_querychat_greeter.py
@@ -8,14 +8,18 @@ from typing import TYPE_CHECKING, Literal
 from ._querychat_core import GREETING_PROMPT
 
 if TYPE_CHECKING:
-    from ._querychat_base import QueryChatBase
+    from collections.abc import Callable
+
+    import chatlas
+
+    from shiny import reactive
 
 
 class QueryChatGreeter:
     """Controls greeting generation for a QueryChat instance. Access via ``qc.greeter``."""
 
-    def __init__(self, parent: QueryChatBase) -> None:
-        self._parent = parent
+    def __init__(self, client_factory: Callable[..., chatlas.Chat]) -> None:
+        self._client_factory = client_factory
         self._tables: list[str] = []
         self._prompt: str | Path = Path(__file__).parent / "prompts" / "greeting.md"
 
@@ -49,9 +53,27 @@ class QueryChatGreeter:
     def prompt(self, value: str | Path) -> None:
         self._prompt = value
 
-    def generate(self, *, echo: Literal["none", "output"] = "none") -> str:
+    def build_client(self, base: str | chatlas.Chat | None = None) -> chatlas.Chat:
+        """Build a greeting chat client using the injected factory."""
+        return self._client_factory(self._tables, self._prompt, base)
+
+    def generate(self, *, echo: Literal["none", "output"] = "none", base=None) -> str:
         """Generate a greeting using the greeting system prompt."""
-        chat = self._parent._build_greeting_client()
-        txt = str(chat.chat(GREETING_PROMPT, echo=echo))
-        self._parent.greeting = txt
-        return txt
+        return str(self.build_client(base).chat(GREETING_PROMPT, echo=echo))
+
+    async def generate_stream(
+        self,
+        *,
+        chat_ui,
+        current_greeting: reactive.Value[str | None],
+        base: str | chatlas.Chat | None = None,
+    ) -> None:
+        """Stream a greeting into the Shiny chat UI and capture the result."""
+        import shinychat
+
+        client = self.build_client(base)
+        stream = await client.stream_async(GREETING_PROMPT, echo="none")
+        await chat_ui.set_greeting(shinychat.chat_greeting(stream, dismissible=False))
+        last_turn = client.get_last_turn(role="assistant")
+        if last_turn is not None:
+            current_greeting.set(last_turn.text)

--- a/pkg-py/src/querychat/_querychat_greeter.py
+++ b/pkg-py/src/querychat/_querychat_greeter.py
@@ -53,11 +53,13 @@ class QueryChatGreeter:
     def prompt(self, value: str | Path) -> None:
         self._prompt = value
 
-    def build_client(self, base: str | chatlas.Chat | None = None) -> chatlas.Chat:
+    def build_client(self, base: chatlas.Chat | None = None) -> chatlas.Chat:
         """Build a greeting chat client using the injected factory."""
         return self._client_factory(self._tables, self._prompt, base)
 
-    def generate(self, *, echo: Literal["none", "output"] = "none", base=None) -> str:
+    def generate(
+        self, *, echo: Literal["none", "output"] = "none", base: chatlas.Chat | None = None
+    ) -> str:
         """Generate a greeting using the greeting system prompt."""
         return str(self.build_client(base).chat(GREETING_PROMPT, echo=echo))
 
@@ -66,7 +68,7 @@ class QueryChatGreeter:
         *,
         chat_ui,
         current_greeting: reactive.Value[str | None],
-        base: str | chatlas.Chat | None = None,
+        base: chatlas.Chat | None = None,
     ) -> None:
         """Stream a greeting into the Shiny chat UI and capture the result."""
         import shinychat

--- a/pkg-py/src/querychat/_shiny.py
+++ b/pkg-py/src/querychat/_shiny.py
@@ -330,7 +330,8 @@ class QueryChat(QueryChatBase[IntoFrameT]):
                 client=self._create_session_client,
                 enable_bookmarking=enable_bookmarking,
                 tools=self.tools,
-                greeting_client_fn=self._build_greeting_client,
+                greeter=self.greeter,
+                greeting_base=None,
             )
 
             @reactive.calc
@@ -540,9 +541,6 @@ class QueryChat(QueryChatBase[IntoFrameT]):
                 client_spec=resolved_client_spec, **kwargs
             )
 
-        def create_greeting_client() -> chatlas.Chat:
-            return self._build_greeting_client(client_spec=resolved_client_spec)
-
         self._mark_server_initialized()
         return mod_server(
             id or self.id,
@@ -552,7 +550,8 @@ class QueryChat(QueryChatBase[IntoFrameT]):
             client=create_session_client,
             enable_bookmarking=enable_bookmarking,
             tools=self.tools,
-            greeting_client_fn=create_greeting_client,
+            greeter=self.greeter,
+            greeting_base=resolved_client_spec,
         )
 
 
@@ -833,7 +832,8 @@ class QueryChatExpress(QueryChatBase[IntoFrameT]):
             client=self._create_session_client,
             enable_bookmarking=self._enable_bookmarking,
             tools=self.tools,
-            greeting_client_fn=self._build_greeting_client,
+            greeter=self.greeter,
+            greeting_base=None,
         )
 
     def sidebar(

--- a/pkg-py/src/querychat/_shiny.py
+++ b/pkg-py/src/querychat/_shiny.py
@@ -540,6 +540,9 @@ class QueryChat(QueryChatBase[IntoFrameT]):
                 client_spec=resolved_client_spec, **kwargs
             )
 
+        def create_greeting_client() -> chatlas.Chat:
+            return self._build_greeting_client(client_spec=resolved_client_spec)
+
         self._mark_server_initialized()
         return mod_server(
             id or self.id,
@@ -549,7 +552,7 @@ class QueryChat(QueryChatBase[IntoFrameT]):
             client=create_session_client,
             enable_bookmarking=enable_bookmarking,
             tools=self.tools,
-            greeting_client_fn=self._build_greeting_client,
+            greeting_client_fn=create_greeting_client,
         )
 
 

--- a/pkg-py/src/querychat/_shiny.py
+++ b/pkg-py/src/querychat/_shiny.py
@@ -330,6 +330,7 @@ class QueryChat(QueryChatBase[IntoFrameT]):
                 client=self._create_session_client,
                 enable_bookmarking=enable_bookmarking,
                 tools=self.tools,
+                greeting_client_fn=self._build_greeting_client,
             )
 
             @reactive.calc
@@ -439,7 +440,12 @@ class QueryChat(QueryChatBase[IntoFrameT]):
             A UI component.
 
         """
-        return mod_ui(id or self.id, preload_viz=has_viz_tool(self.tools), greeting=self.greeting, **kwargs)
+        return mod_ui(
+            id or self.id,
+            preload_viz=has_viz_tool(self.tools),
+            greeting=self.greeting,
+            **kwargs,
+        )
 
     def server(
         self,
@@ -525,7 +531,9 @@ class QueryChat(QueryChatBase[IntoFrameT]):
             )
 
         self._require_initialized("server")
-        resolved_client_spec = self._client_spec if isinstance(client, MISSING_TYPE) else client
+        resolved_client_spec = (
+            self._client_spec if isinstance(client, MISSING_TYPE) else client
+        )
 
         def create_session_client(**kwargs) -> chatlas.Chat:
             return self._create_session_client(
@@ -541,6 +549,7 @@ class QueryChat(QueryChatBase[IntoFrameT]):
             client=create_session_client,
             enable_bookmarking=enable_bookmarking,
             tools=self.tools,
+            greeting_client_fn=self._build_greeting_client,
         )
 
 
@@ -821,6 +830,7 @@ class QueryChatExpress(QueryChatBase[IntoFrameT]):
             client=self._create_session_client,
             enable_bookmarking=self._enable_bookmarking,
             tools=self.tools,
+            greeting_client_fn=self._build_greeting_client,
         )
 
     def sidebar(
@@ -882,7 +892,12 @@ class QueryChatExpress(QueryChatBase[IntoFrameT]):
             A UI component.
 
         """
-        result = mod_ui(id or self.id, preload_viz=has_viz_tool(self.tools), greeting=self.greeting, **kwargs)
+        result = mod_ui(
+            id or self.id,
+            preload_viz=has_viz_tool(self.tools),
+            greeting=self.greeting,
+            **kwargs,
+        )
         self._ensure_server_started()
         return result
 
@@ -998,9 +1013,11 @@ class QueryChatExpress(QueryChatBase[IntoFrameT]):
         qc.add_table(customers, "customers")
         qc.sidebar()
 
+
         @render.data_frame
         def orders_table():
             return qc.table("orders").df()
+
 
         @render.data_frame
         def customers_table():

--- a/pkg-py/src/querychat/_shiny.py
+++ b/pkg-py/src/querychat/_shiny.py
@@ -10,7 +10,7 @@ from shinychat import output_markdown_stream
 from shiny import App, Inputs, Outputs, Session, reactive, render, req, ui
 
 from ._icons import bs_icon
-from ._querychat_base import DEFAULT_TOOLS, TOOL_GROUPS, QueryChatBase
+from ._querychat_base import DEFAULT_TOOLS, TOOL_GROUPS, QueryChatBase, resolve_client
 from ._shiny_module import ServerValues, mod_server, mod_ui
 from ._utils import MISSING, MISSING_TYPE, as_narwhals
 from ._viz_utils import has_viz_tool
@@ -532,14 +532,12 @@ class QueryChat(QueryChatBase[IntoFrameT]):
             )
 
         self._require_initialized("server")
-        resolved_client_spec = (
-            self._client_spec if isinstance(client, MISSING_TYPE) else client
+        resolved_client: chatlas.Chat | None = (
+            None if isinstance(client, MISSING_TYPE) else resolve_client(client)
         )
 
         def create_session_client(**kwargs) -> chatlas.Chat:
-            return self._create_session_client(
-                client_spec=resolved_client_spec, **kwargs
-            )
+            return self._create_session_client(base=resolved_client, **kwargs)
 
         self._mark_server_initialized()
         return mod_server(
@@ -551,7 +549,7 @@ class QueryChat(QueryChatBase[IntoFrameT]):
             enable_bookmarking=enable_bookmarking,
             tools=self.tools,
             greeter=self.greeter,
-            greeting_base=resolved_client_spec,
+            greeting_base=resolved_client,
         )
 
 

--- a/pkg-py/src/querychat/_shiny_module.py
+++ b/pkg-py/src/querychat/_shiny_module.py
@@ -8,12 +8,12 @@ from typing import TYPE_CHECKING, Generic, TypedDict, Union
 import chatlas
 import shinychat
 from narwhals.stable.v1.typing import IntoFrameT
-from shinychat import Attachment, attachment_to_content
-
 from shiny import module, reactive, ui
+from shinychat import Attachment, attachment_to_content
 
 from ._querychat_core import warn_multi_table_flat_accessor
 from ._table_accessor import TableAccessor
+from ._utils_shinychat import chat_greeting_persistent
 from ._viz_altair_widget import AltairWidget
 from ._viz_ggsql import execute_ggsql
 from ._viz_utils import has_viz_tool, preload_viz_deps_server, preload_viz_deps_ui
@@ -21,9 +21,8 @@ from ._viz_utils import has_viz_tool, preload_viz_deps_server, preload_viz_deps_
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from shiny.bookmark import BookmarkState, RestoreState
-
     from shiny import Inputs, Outputs, Session
+    from shiny.bookmark import BookmarkState, RestoreState
 
     from ._datasource import DataSource
     from ._query_executor import QueryExecutor
@@ -77,7 +76,7 @@ def mod_ui(*, preload_viz: bool = False, greeting: str | None = None, **kwargs):
     kwargs.setdefault("allow_attachments", True)
     if greeting:
         kwargs.setdefault(
-            "greeting", shinychat.chat_greeting(greeting, persistent=True, dismissible=False)  # pyright: ignore[reportArgumentType]
+            "greeting", chat_greeting_persistent(greeting)
         )
     tag = shinychat.chat_ui(CHAT_ID, **kwargs)
     tag.add_class("querychat")
@@ -339,7 +338,7 @@ def mod_server(
             existing = current_greeting.get()
             if existing is not None:
                 await chat_ui.set_greeting(
-                    shinychat.chat_greeting(existing, persistent=True, dismissible=False)  # pyright: ignore[reportArgumentType]
+                    chat_greeting_persistent(existing)
                 )
                 return
             warnings.warn(
@@ -402,9 +401,7 @@ def mod_server(
             if "querychat_greeting" in vals:
                 current_greeting.set(vals["querychat_greeting"])
                 await chat_ui.set_greeting(
-                    shinychat.chat_greeting(
-                        vals["querychat_greeting"], persistent=True, dismissible=False  # pyright: ignore[reportArgumentType]
-                    )
+                    chat_greeting_persistent(vals["querychat_greeting"])
                 )
             if "querychat_viz_widgets" in vals:
                 restored = restore_viz_widgets(executor, vals["querychat_viz_widgets"])

--- a/pkg-py/src/querychat/_shiny_module.py
+++ b/pkg-py/src/querychat/_shiny_module.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 
     from ._datasource import DataSource
     from ._query_executor import QueryExecutor
+    from ._querychat_greeter import QueryChatGreeter
     from ._viz_tools import VisualizeData
     from .types import UpdateDashboardData
 
@@ -214,7 +215,8 @@ def mod_server(
     client: Callable[..., chatlas.Chat],
     enable_bookmarking: bool,
     tools: set[str] | None = None,
-    greeting_client_fn: Callable[[], chatlas.Chat] | None = None,
+    greeter: QueryChatGreeter | None = None,
+    greeting_base: str | chatlas.Chat | None = None,
 ) -> ServerValues[IntoFrameT]:
     # Holds a generated greeting so it can be saved and restored on bookmark.
     # Static greetings live in the UI (chat_ui(greeting=)) and persist already.
@@ -347,19 +349,23 @@ def mod_server(
                 GreetWarning,
                 stacklevel=2,
             )
-            greeting_client = (
-                greeting_client_fn()
-                if greeting_client_fn is not None
-                else client(tools=None)
-            )
-            stream = await greeting_client.stream_async(GREETING_PROMPT, echo="none")
-            await chat_ui.set_greeting(
-                shinychat.chat_greeting(stream, dismissible=False)
-            )
-            # Capture the generated greeting so it can be bookmarked and restored.
-            last_turn = greeting_client.get_last_turn(role="assistant")
-            if last_turn is not None:
-                current_greeting.set(last_turn.text)
+            if greeter is not None:
+                await greeter.generate_stream(
+                    chat_ui=chat_ui,
+                    current_greeting=current_greeting,
+                    base=greeting_base,
+                )
+            else:
+                fallback_client = client(tools=None)
+                stream = await fallback_client.stream_async(
+                    GREETING_PROMPT, echo="none"
+                )
+                await chat_ui.set_greeting(
+                    shinychat.chat_greeting(stream, dismissible=False)
+                )
+                last_turn = fallback_client.get_last_turn(role="assistant")
+                if last_turn is not None:
+                    current_greeting.set(last_turn.text)
 
     # Handle update button clicks
     @reactive.effect

--- a/pkg-py/src/querychat/_shiny_module.py
+++ b/pkg-py/src/querychat/_shiny_module.py
@@ -67,7 +67,6 @@ class TableState(Generic[IntoFrameT]):
     df: Callable[[], IntoFrameT]
 
 
-
 @module.ui
 def mod_ui(*, preload_viz: bool = False, greeting: str | None = None, **kwargs):
     css_path = Path(__file__).parent / "static" / "css" / "styles.css"
@@ -215,6 +214,7 @@ def mod_server(
     client: Callable[..., chatlas.Chat],
     enable_bookmarking: bool,
     tools: set[str] | None = None,
+    greeting_client_fn: Callable[[], chatlas.Chat] | None = None,
 ) -> ServerValues[IntoFrameT]:
     # Holds a generated greeting so it can be saved and restored on bookmark.
     # Static greetings live in the UI (chat_ui(greeting=)) and persist already.
@@ -347,7 +347,11 @@ def mod_server(
                 GreetWarning,
                 stacklevel=2,
             )
-            greeting_client = client(tools=None)
+            greeting_client = (
+                greeting_client_fn()
+                if greeting_client_fn is not None
+                else client(tools=None)
+            )
             stream = await greeting_client.stream_async(GREETING_PROMPT, echo="none")
             await chat_ui.set_greeting(
                 shinychat.chat_greeting(stream, dismissible=False)
@@ -409,9 +413,7 @@ def mod_server(
                     )
                 )
             if "querychat_viz_widgets" in vals:
-                restored = restore_viz_widgets(
-                    executor, vals["querychat_viz_widgets"]
-                )
+                restored = restore_viz_widgets(executor, vals["querychat_viz_widgets"])
                 viz_widgets[:] = restored
 
     if len(table_states) == 1:
@@ -443,7 +445,9 @@ def mod_server(
     return ServerValues(
         df=_multi_table_df,
         sql=_MultiTableWarnReactive(primary_state.sql, "sql", primary_name, table_list),  # type: ignore[arg-type]
-        title=_MultiTableWarnReactive(primary_state.title, "title", primary_name, table_list),  # type: ignore[arg-type]
+        title=_MultiTableWarnReactive(
+            primary_state.title, "title", primary_name, table_list
+        ),  # type: ignore[arg-type]
         tables=table_states,
         client=chat,
         data_sources=data_sources,

--- a/pkg-py/src/querychat/_shiny_module.py
+++ b/pkg-py/src/querychat/_shiny_module.py
@@ -8,8 +8,9 @@ from typing import TYPE_CHECKING, Generic, TypedDict, Union
 import chatlas
 import shinychat
 from narwhals.stable.v1.typing import IntoFrameT
-from shiny import module, reactive, ui
 from shinychat import Attachment, attachment_to_content
+
+from shiny import module, reactive, ui
 
 from ._querychat_core import warn_multi_table_flat_accessor
 from ._table_accessor import TableAccessor
@@ -21,8 +22,9 @@ from ._viz_utils import has_viz_tool, preload_viz_deps_server, preload_viz_deps_
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from shiny import Inputs, Outputs, Session
     from shiny.bookmark import BookmarkState, RestoreState
+
+    from shiny import Inputs, Outputs, Session
 
     from ._datasource import DataSource
     from ._query_executor import QueryExecutor
@@ -75,9 +77,7 @@ def mod_ui(*, preload_viz: bool = False, greeting: str | None = None, **kwargs):
     kwargs.setdefault("enable_cancel", True)
     kwargs.setdefault("allow_attachments", True)
     if greeting:
-        kwargs.setdefault(
-            "greeting", chat_greeting_persistent(greeting)
-        )
+        kwargs.setdefault("greeting", chat_greeting_persistent(greeting))
     tag = shinychat.chat_ui(CHAT_ID, **kwargs)
     tag.add_class("querychat")
 
@@ -337,9 +337,7 @@ def mod_server(
             # fires, so on_restore is the only path that re-displays.
             existing = current_greeting.get()
             if existing is not None:
-                await chat_ui.set_greeting(
-                    chat_greeting_persistent(existing)
-                )
+                await chat_ui.set_greeting(chat_greeting_persistent(existing))
                 return
             warnings.warn(
                 "No greeting provided to `QueryChat()`. Using the LLM `client` to generate one now. "

--- a/pkg-py/src/querychat/_shiny_module.py
+++ b/pkg-py/src/querychat/_shiny_module.py
@@ -12,7 +12,7 @@ from shinychat import Attachment, attachment_to_content
 
 from shiny import module, reactive, ui
 
-from ._querychat_core import GREETING_PROMPT, warn_multi_table_flat_accessor
+from ._querychat_core import warn_multi_table_flat_accessor
 from ._table_accessor import TableAccessor
 from ._viz_altair_widget import AltairWidget
 from ._viz_ggsql import execute_ggsql
@@ -215,7 +215,7 @@ def mod_server(
     client: Callable[..., chatlas.Chat],
     enable_bookmarking: bool,
     tools: set[str] | None = None,
-    greeter: QueryChatGreeter | None = None,
+    greeter: QueryChatGreeter,
     greeting_base: str | chatlas.Chat | None = None,
 ) -> ServerValues[IntoFrameT]:
     # Holds a generated greeting so it can be saved and restored on bookmark.
@@ -349,23 +349,11 @@ def mod_server(
                 GreetWarning,
                 stacklevel=2,
             )
-            if greeter is not None:
-                await greeter.generate_stream(
-                    chat_ui=chat_ui,
-                    current_greeting=current_greeting,
-                    base=greeting_base,
-                )
-            else:
-                fallback_client = client(tools=None)
-                stream = await fallback_client.stream_async(
-                    GREETING_PROMPT, echo="none"
-                )
-                await chat_ui.set_greeting(
-                    shinychat.chat_greeting(stream, dismissible=False)
-                )
-                last_turn = fallback_client.get_last_turn(role="assistant")
-                if last_turn is not None:
-                    current_greeting.set(last_turn.text)
+            await greeter.generate_stream(
+                chat_ui=chat_ui,
+                current_greeting=current_greeting,
+                base=greeting_base,
+            )
 
     # Handle update button clicks
     @reactive.effect

--- a/pkg-py/src/querychat/_shiny_module.py
+++ b/pkg-py/src/querychat/_shiny_module.py
@@ -77,7 +77,7 @@ def mod_ui(*, preload_viz: bool = False, greeting: str | None = None, **kwargs):
     kwargs.setdefault("allow_attachments", True)
     if greeting:
         kwargs.setdefault(
-            "greeting", shinychat.chat_greeting(greeting, dismissible=False)
+            "greeting", shinychat.chat_greeting(greeting, persistent=True, dismissible=False)  # pyright: ignore[reportArgumentType]
         )
     tag = shinychat.chat_ui(CHAT_ID, **kwargs)
     tag.add_class("querychat")
@@ -339,7 +339,7 @@ def mod_server(
             existing = current_greeting.get()
             if existing is not None:
                 await chat_ui.set_greeting(
-                    shinychat.chat_greeting(existing, dismissible=False)
+                    shinychat.chat_greeting(existing, persistent=True, dismissible=False)  # pyright: ignore[reportArgumentType]
                 )
                 return
             warnings.warn(
@@ -403,7 +403,7 @@ def mod_server(
                 current_greeting.set(vals["querychat_greeting"])
                 await chat_ui.set_greeting(
                     shinychat.chat_greeting(
-                        vals["querychat_greeting"], dismissible=False
+                        vals["querychat_greeting"], persistent=True, dismissible=False  # pyright: ignore[reportArgumentType]
                     )
                 )
             if "querychat_viz_widgets" in vals:

--- a/pkg-py/src/querychat/_shiny_module.py
+++ b/pkg-py/src/querychat/_shiny_module.py
@@ -216,7 +216,7 @@ def mod_server(
     enable_bookmarking: bool,
     tools: set[str] | None = None,
     greeter: QueryChatGreeter,
-    greeting_base: str | chatlas.Chat | None = None,
+    greeting_base: chatlas.Chat | None = None,
 ) -> ServerValues[IntoFrameT]:
     # Holds a generated greeting so it can be saved and restored on bookmark.
     # Static greetings live in the UI (chat_ui(greeting=)) and persist already.

--- a/pkg-py/src/querychat/_streamlit.py
+++ b/pkg-py/src/querychat/_streamlit.py
@@ -225,7 +225,7 @@ class QueryChat(QueryChatBase[IntoFrameT]):
                 ),
                 greeting=self.greeting,
                 query_executor=self._require_query_executor("_get_state"),
-                greeting_client_factory=self._build_greeting_client,
+                greeting_client_factory=self.greeter.build_client,
             )
         return st.session_state[self._state_key]
 

--- a/pkg-py/src/querychat/_streamlit.py
+++ b/pkg-py/src/querychat/_streamlit.py
@@ -225,6 +225,7 @@ class QueryChat(QueryChatBase[IntoFrameT]):
                 ),
                 greeting=self.greeting,
                 query_executor=self._require_query_executor("_get_state"),
+                greeting_client_factory=self._build_greeting_client,
             )
         return st.session_state[self._state_key]
 
@@ -291,7 +292,8 @@ class QueryChat(QueryChatBase[IntoFrameT]):
                 with st.chat_message("assistant"):
                     placeholder = st.empty()
                     placeholder.markdown("*Preparing your data assistant...*")
-                    for chunk in stream_response(state.client, GREETING_PROMPT):
+                    greeting_client = state.build_greeting_client()
+                    for chunk in stream_response(greeting_client, GREETING_PROMPT):
                         greeting += chunk
                         placeholder.markdown(greeting, unsafe_allow_html=True)
                 state.set_greeting(greeting)

--- a/pkg-py/src/querychat/_system_prompt.py
+++ b/pkg-py/src/querychat/_system_prompt.py
@@ -164,6 +164,7 @@ class QueryChatSystemPrompt:
         context = {
             "db_type": db_type,
             "is_duck_db": db_type.lower() == "duckdb",
+            "has_tables": first_source is not None,
             "semantic_views": semantic_views,
             "has_data_dicts": has_dicts,
             "data_dicts": data_dicts,

--- a/pkg-py/src/querychat/_system_prompt.py
+++ b/pkg-py/src/querychat/_system_prompt.py
@@ -33,7 +33,7 @@ class QueryChatSystemPrompt:
         elif data_source is not None:
             self._data_sources = {data_source.table_name: data_source}
         else:
-            raise ValueError("Either data_source or data_sources must be provided")
+            self._data_sources = {}
 
         self._data_dicts: list[DataDict] = data_dicts or []
 
@@ -102,8 +102,18 @@ class QueryChatSystemPrompt:
             if dd.description:
                 attrs += f' description="{escape_attr(dd.description)}"'
 
-            body = yaml.dump(d, default_flow_style=False, allow_unicode=True, sort_keys=False).rstrip() if d else ""
-            blocks.append(f"<data-dict {attrs}>\n{body}\n</data-dict>" if body else f"<data-dict {attrs}/>")
+            body = (
+                yaml.dump(
+                    d, default_flow_style=False, allow_unicode=True, sort_keys=False
+                ).rstrip()
+                if d
+                else ""
+            )
+            blocks.append(
+                f"<data-dict {attrs}>\n{body}\n</data-dict>"
+                if body
+                else f"<data-dict {attrs}/>"
+            )
 
         unclaimed = [n for n in self._data_sources if n not in all_claimed]
         if unclaimed:
@@ -115,7 +125,12 @@ class QueryChatSystemPrompt:
                     else None
                 )
                 tables[name] = {"description": desc} if desc else None
-            yaml_str = yaml.dump({"tables": tables}, default_flow_style=False, allow_unicode=True, sort_keys=False).rstrip()
+            yaml_str = yaml.dump(
+                {"tables": tables},
+                default_flow_style=False,
+                allow_unicode=True,
+                sort_keys=False,
+            ).rstrip()
             blocks.append(f"<tables>\n{yaml_str}\n</tables>")
 
         return "\n\n".join(blocks)
@@ -131,17 +146,28 @@ class QueryChatSystemPrompt:
             Fully rendered system prompt string
 
         """
-        first_source = next(iter(self._data_sources.values()))
-        db_type = first_source.get_db_type()
-        has_dicts = bool(self._data_dicts)
+        first_source = next(iter(self._data_sources.values()), None)
+        db_type = first_source.get_db_type() if first_source is not None else "SQL"
+        has_dicts = first_source is not None and bool(self._data_dicts)
+        semantic_views = (
+            first_source.get_semantic_views_description()
+            if first_source is not None
+            else ""
+        )
+        tables_overview = (
+            ""
+            if has_dicts
+            else (self._generate_tables_overview() if first_source is not None else "")
+        )
+        data_dicts = self._generate_data_dicts_yaml() if has_dicts else ""
 
         context = {
             "db_type": db_type,
             "is_duck_db": db_type.lower() == "duckdb",
-            "semantic_views": first_source.get_semantic_views_description(),
+            "semantic_views": semantic_views,
             "has_data_dicts": has_dicts,
-            "data_dicts": self._generate_data_dicts_yaml() if has_dicts else "",
-            "tables_overview": "" if has_dicts else self._generate_tables_overview(),
+            "data_dicts": data_dicts,
+            "tables_overview": tables_overview,
             "data_description": self.data_description,
             "extra_instructions": self.extra_instructions,
             "has_tool_update": "update" in tools if tools else False,

--- a/pkg-py/src/querychat/_system_prompt.py
+++ b/pkg-py/src/querychat/_system_prompt.py
@@ -148,7 +148,9 @@ class QueryChatSystemPrompt:
         """
         first_source = next(iter(self._data_sources.values()), None)
         db_type = first_source.get_db_type() if first_source is not None else "SQL"
-        has_dicts = first_source is not None and bool(self._data_dicts)
+        # Data dicts can carry global (table-less) descriptions, so they may
+        # render even when no tables are selected (e.g. a generic greeting).
+        has_dicts = bool(self._data_dicts)
         semantic_views = (
             first_source.get_semantic_views_description()
             if first_source is not None

--- a/pkg-py/src/querychat/_system_prompt.py
+++ b/pkg-py/src/querychat/_system_prompt.py
@@ -27,6 +27,9 @@ class QueryChatSystemPrompt:
         extra_instructions: str | Path | None = None,
         categorical_threshold: int = 20,
         data_dicts: list[DataDict] | None = None,
+        include_tables: bool | list[str] = True,
+        include_relationships: bool = True,
+        include_glossary: bool = True,
     ):
         if data_sources is not None:
             self._data_sources = data_sources
@@ -37,7 +40,34 @@ class QueryChatSystemPrompt:
 
         self._data_dicts: list[DataDict] = data_dicts or []
 
-        if len(self._data_sources) > 1 and not self._data_dicts:
+        if include_tables is not True:
+            resolved = (
+                []
+                if include_tables is False
+                else [n for n in include_tables if n in self._data_sources]
+            )
+            self._data_sources = {n: self._data_sources[n] for n in resolved}
+            self._data_dicts = [
+                dd
+                for dd in self._data_dicts
+                if any(n in resolved for n in dd.tables)
+                or (not dd.tables and dd.description)
+            ]
+            update: dict[str, object] = {}
+            if not include_relationships:
+                update["relationships"] = []
+            if not include_glossary:
+                update["glossary"] = {}
+            if update:
+                self._data_dicts = [
+                    dd.model_copy(update=update) for dd in self._data_dicts
+                ]
+
+        if (
+            include_tables is True
+            and len(self._data_sources) > 1
+            and not self._data_dicts
+        ):
             warnings.warn(
                 "Multiple tables registered without a data_dict. "
                 "Providing a data_dict with table descriptions and relationships "

--- a/pkg-py/src/querychat/_table_accessor.py
+++ b/pkg-py/src/querychat/_table_accessor.py
@@ -59,4 +59,3 @@ class TableAccessor:
     def title(self) -> str | None:
         """Return the current filter title for this table (reactive)."""
         return self._state.title.get()
-

--- a/pkg-py/src/querychat/_utils_shinychat.py
+++ b/pkg-py/src/querychat/_utils_shinychat.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     from shinychat._chat_types import ChatGreeting
 
 
-# TODO: remove once shinychat >= 0.5.0 is the minimum (persistent added in 0.4.0.9000)
+# TODO @gadenbuie: remove once shinychat >= 0.5.0 is the minimum (persistent added in 0.4.0.9000)
 def chat_greeting_persistent(content: Any) -> ChatGreeting:
     from importlib.metadata import version
 

--- a/pkg-py/src/querychat/_utils_shinychat.py
+++ b/pkg-py/src/querychat/_utils_shinychat.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from shinychat._chat_types import ChatGreeting
+
+
+def chat_greeting_persistent(content: Any) -> ChatGreeting:
+    from importlib.metadata import version
+
+    import shinychat
+    from packaging.version import Version
+
+    if Version(version("shinychat")) > Version("0.4.0"):
+        return shinychat.chat_greeting(content, persistent=True)
+    else:
+        return shinychat.chat_greeting(content, dismissible=False)  # pyright: ignore[reportArgumentType]

--- a/pkg-py/src/querychat/_utils_shinychat.py
+++ b/pkg-py/src/querychat/_utils_shinychat.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from shinychat._chat_types import ChatGreeting
 
 
+# TODO: remove once shinychat >= 0.5.0 is the minimum (persistent added in 0.4.0.9000)
 def chat_greeting_persistent(content: Any) -> ChatGreeting:
     from importlib.metadata import version
 

--- a/pkg-py/src/querychat/_viz_altair_widget.py
+++ b/pkg-py/src/querychat/_viz_altair_widget.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     import altair as alt
     import ggsql
 
+
 class AltairWidget:
     """
     An Altair chart wrapped in ``alt.JupyterChart`` for display in Shiny.
@@ -110,9 +111,7 @@ class AltairWidget:
 DEFAULT_COMPOUND_WIDTH = 900
 DEFAULT_COMPOUND_HEIGHT = 450
 
-LEGEND_CHANNELS = frozenset(
-    {"color", "fill", "stroke", "shape", "size", "opacity"}
-)
+LEGEND_CHANNELS = frozenset({"color", "fill", "stroke", "shape", "size", "opacity"})
 LEGEND_WIDTH = 120  # approximate space for a right-side legend
 
 
@@ -184,14 +183,30 @@ def infer_grid_facet_dims(chart: alt.FacetChart) -> tuple[int, int] | None:
     import pandas as pd
 
     facet_dict = chart.facet.to_dict()
-    row_field = facet_dict.get("row", {}).get("field") if isinstance(facet_dict.get("row"), dict) else None
-    col_field = facet_dict.get("column", {}).get("field") if isinstance(facet_dict.get("column"), dict) else None
+    row_field = (
+        facet_dict.get("row", {}).get("field")
+        if isinstance(facet_dict.get("row"), dict)
+        else None
+    )
+    col_field = (
+        facet_dict.get("column", {}).get("field")
+        if isinstance(facet_dict.get("column"), dict)
+        else None
+    )
     if row_field is None and col_field is None:
         return None
     if not isinstance(chart.data, pd.DataFrame):
         return None
-    ncol = int(chart.data[col_field].nunique()) if col_field and col_field in chart.data.columns else 1  # type: ignore[arg-type]
-    nrow = int(chart.data[row_field].nunique()) if row_field and row_field in chart.data.columns else 1  # type: ignore[arg-type]
+    ncol = (
+        int(chart.data[col_field].nunique())
+        if col_field and col_field in chart.data.columns
+        else 1
+    )  # type: ignore[arg-type]
+    nrow = (
+        int(chart.data[row_field].nunique())
+        if row_field and row_field in chart.data.columns
+        else 1
+    )  # type: ignore[arg-type]
     return (max(ncol, 1), max(nrow, 1))
 
 

--- a/pkg-py/src/querychat/_viz_altair_widget.py
+++ b/pkg-py/src/querychat/_viz_altair_widget.py
@@ -198,15 +198,15 @@ def infer_grid_facet_dims(chart: alt.FacetChart) -> tuple[int, int] | None:
     if not isinstance(chart.data, pd.DataFrame):
         return None
     ncol = (
-        int(chart.data[col_field].nunique())
+        int(chart.data[col_field].nunique())  # type: ignore[arg-type]
         if col_field and col_field in chart.data.columns
         else 1
-    )  # type: ignore[arg-type]
+    )
     nrow = (
-        int(chart.data[row_field].nunique())
+        int(chart.data[row_field].nunique())  # type: ignore[arg-type]
         if row_field and row_field in chart.data.columns
         else 1
-    )  # type: ignore[arg-type]
+    )
     return (max(ncol, 1), max(nrow, 1))
 
 

--- a/pkg-py/src/querychat/_viz_tools.py
+++ b/pkg-py/src/querychat/_viz_tools.py
@@ -239,6 +239,7 @@ def visualize_impl(
 
     return visualize
 
+
 PNG_WIDTH = 500
 PNG_HEIGHT = 300
 

--- a/pkg-py/src/querychat/prompts/greeting.md
+++ b/pkg-py/src/querychat/prompts/greeting.md
@@ -3,21 +3,23 @@ You are a friendly data assistant. Write a warm welcome greeting for a user who 
 {{#has_tables}}
 You have access to a {{db_type}} database with the following tables:
 
-{{#has_data_dicts}}
-{{{data_dicts}}}
-
-{{/has_data_dicts}}
-{{^has_data_dicts}}
-<tables>
-{{{tables_overview}}}
-</tables>
-
-{{/has_data_dicts}}
 {{/has_tables}}
 {{^has_tables}}
 You have access to a {{db_type}} database.
 
 {{/has_tables}}
+{{#has_data_dicts}}
+{{{data_dicts}}}
+
+{{/has_data_dicts}}
+{{^has_data_dicts}}
+{{#has_tables}}
+<tables>
+{{{tables_overview}}}
+</tables>
+
+{{/has_tables}}
+{{/has_data_dicts}}
 {{#data_description}}
 <data_description>
 {{{data_description}}}

--- a/pkg-py/src/querychat/prompts/greeting.md
+++ b/pkg-py/src/querychat/prompts/greeting.md
@@ -1,0 +1,62 @@
+You are a friendly data assistant. Write a warm welcome greeting for a user who is about to explore their data.
+
+You have access to a {{db_type}} SQL database with the following tables:
+
+{{#has_data_dicts}}
+{{{data_dicts}}}
+
+{{/has_data_dicts}}
+{{^has_data_dicts}}
+<tables>
+{{{tables_overview}}}
+</tables>
+
+{{/has_data_dicts}}
+{{#data_description}}
+<data_description>
+{{{data_description}}}
+</data_description>
+
+{{/data_description}}
+Your greeting should be brief, warm, and focused on what the user can do with this data. Mention 2–4 concrete things the user might want to explore or ask about.
+
+### Providing Suggestions for Next Steps
+
+#### Suggestion Syntax
+
+Use `<span class="suggestion">` tags to create clickable suggestion buttons in the UI. The text inside should be a complete, actionable suggestion that users can click to continue the conversation.
+
+**List format (most common):**
+```
+<ul>
+<li><span class="suggestion">Show me examples of …</span></li>
+<li><span class="suggestion">What are the key differences between …</span></li>
+<li><span class="suggestion">Explain how …</span></li>
+</ul>
+```
+
+Use explicit HTML `<ul>`/`<li>` tags instead of markdown list markers (`*`, `-`). Markdown lists work when formatted correctly, but omitting the space after the marker (e.g., `-<span>` instead of `- <span>`) silently breaks the list parse, so HTML tags are more reliable.
+
+**Grouped suggestions:**
+```
+##### Explore the data
+<ul>
+<li><span class="suggestion">What tables are available?</span></li>
+<li><span class="suggestion">What columns does … have?</span></li>
+</ul>
+
+##### Analyze the data
+<ul>
+<li><span class="suggestion">What's the average …?</span></li>
+<li><span class="suggestion">How many …?</span></li>
+</ul>
+```
+
+#### Suggestion Guidelines
+
+- Use list format with 2–4 concrete, actionable suggestions grouped under `#####` headings
+- Write suggestions as complete, natural prompts (not fragments)
+- Include at least one suggestion encouraging the user to explore what data and questions are available
+- Never use nested lists for suggestions — group them under headings instead
+- Never use generic phrases like "If you'd like to..." — provide concrete suggestions
+- Never refer to suggestions as "prompts" — call them "suggestions" or "ideas" or similar

--- a/pkg-py/src/querychat/prompts/greeting.md
+++ b/pkg-py/src/querychat/prompts/greeting.md
@@ -1,6 +1,7 @@
 You are a friendly data assistant. Write a warm welcome greeting for a user who is about to explore their data.
 
-You have access to a {{db_type}} SQL database with the following tables:
+{{#has_tables}}
+You have access to a {{db_type}} database with the following tables:
 
 {{#has_data_dicts}}
 {{{data_dicts}}}
@@ -12,6 +13,11 @@ You have access to a {{db_type}} SQL database with the following tables:
 </tables>
 
 {{/has_data_dicts}}
+{{/has_tables}}
+{{^has_tables}}
+You have access to a {{db_type}} database.
+
+{{/has_tables}}
 {{#data_description}}
 <data_description>
 {{{data_description}}}

--- a/pkg-py/src/querychat/tools.py
+++ b/pkg-py/src/querychat/tools.py
@@ -114,7 +114,9 @@ def _get_schema_impl(
             columns = executor.get_column_details(table_name, categorical_threshold)
 
         schema_text = format_schema(table_name, columns)
-        return GetSchemaResult(value=schema_text, table_name=table_name, columns=columns)
+        return GetSchemaResult(
+            value=schema_text, table_name=table_name, columns=columns
+        )
 
     return get_schema
 

--- a/pkg-py/tests/playwright/test_01_hello_app.py
+++ b/pkg-py/tests/playwright/test_01_hello_app.py
@@ -281,7 +281,5 @@ class Test01HelloApp:
         self.chat.set_user_input("How many rows are in the dataset?")
         self.chat.send_user_input(method="click")
 
-        send_btn = self.page.locator(
-            ".shiny-chat-btn-send:not(.shiny-chat-btn-cancel)"
-        )
+        send_btn = self.page.locator(".shiny-chat-btn-send:not(.shiny-chat-btn-cancel)")
         expect(send_btn).to_be_visible(timeout=60000)

--- a/pkg-py/tests/playwright/test_10_viz_inline.py
+++ b/pkg-py/tests/playwright/test_10_viz_inline.py
@@ -23,9 +23,7 @@ class TestInlineVisualization:
     """Tests for inline chart rendering in tool result cards."""
 
     @pytest.fixture(autouse=True)
-    def setup(
-        self, page: Page, app_10_viz: str, chat_10_viz: ChatController
-    ) -> None:
+    def setup(self, page: Page, app_10_viz: str, chat_10_viz: ChatController) -> None:
         """Navigate to the viz app before each test."""
         page.goto(app_10_viz)
         page.wait_for_selector("shiny-chat-container", timeout=30000)
@@ -72,7 +70,9 @@ class TestInlineVisualization:
         self.chat.send_user_input(method="click")
 
         # Wait for viz tool result
-        tool_result = self.page.locator(".shiny-tool-result:has(.tool-fullscreen-toggle)")
+        tool_result = self.page.locator(
+            ".shiny-tool-result:has(.tool-fullscreen-toggle)"
+        )
         expect(tool_result).to_be_visible(timeout=90000)
 
         # Click fullscreen toggle
@@ -91,7 +91,9 @@ class TestInlineVisualization:
         self.chat.send_user_input(method="click")
 
         # Wait for viz tool result
-        tool_result = self.page.locator(".shiny-tool-result:has(.tool-fullscreen-toggle)")
+        tool_result = self.page.locator(
+            ".shiny-tool-result:has(.tool-fullscreen-toggle)"
+        )
         expect(tool_result).to_be_visible(timeout=90000)
 
         # Enter fullscreen
@@ -116,7 +118,9 @@ class TestInlineVisualization:
         )
         self.chat.send_user_input(method="click")
 
-        tool_result = self.page.locator(".shiny-tool-result:has(.tool-fullscreen-toggle)")
+        tool_result = self.page.locator(
+            ".shiny-tool-result:has(.tool-fullscreen-toggle)"
+        )
         expect(tool_result).to_be_visible(timeout=90000)
 
         tool_result.locator(".tool-fullscreen-toggle").click()
@@ -145,7 +149,9 @@ class TestInlineVisualization:
         )
         self.chat.send_user_input(method="click")
 
-        tool_result = self.page.locator(".shiny-tool-result:has(.tool-fullscreen-toggle)")
+        tool_result = self.page.locator(
+            ".shiny-tool-result:has(.tool-fullscreen-toggle)"
+        )
         expect(tool_result).to_be_visible(timeout=90000)
 
         tool_result.locator(".tool-fullscreen-toggle").click()
@@ -159,4 +165,3 @@ class TestInlineVisualization:
         footer_box = footer.bounding_box()
         assert footer_box is not None
         assert footer_box["height"] < 100
-

--- a/pkg-py/tests/playwright/test_11_viz_footer.py
+++ b/pkg-py/tests/playwright/test_11_viz_footer.py
@@ -24,9 +24,7 @@ VIZ_PROMPT = "Use the visualize tool to create a scatter plot of age vs fare"
 TOOL_RESULT_TIMEOUT = 90_000
 
 
-def _download_from_save_menu(
-    page: Page, export_format: str
-) -> tuple[Download, str]:
+def _download_from_save_menu(page: Page, export_format: str) -> tuple[Download, str]:
     """Open the save menu, click the requested format, and capture the download."""
     page.locator(".querychat-save-btn").click()
 
@@ -40,9 +38,7 @@ def _download_from_save_menu(
 
 
 @pytest.fixture(autouse=True)
-def _send_viz_prompt(
-    page: Page, app_10_viz: str, chat_10_viz: ChatController
-) -> None:
+def _send_viz_prompt(page: Page, app_10_viz: str, chat_10_viz: ChatController) -> None:
     """Navigate to the viz app and trigger a visualization before each test."""
     page.goto(app_10_viz)
     page.wait_for_selector("shiny-chat-container", timeout=30_000)
@@ -57,9 +53,7 @@ def _send_viz_prompt(
         state="visible", timeout=TOOL_RESULT_TIMEOUT
     )
     # Wait for the footer buttons to appear inside the card
-    page.locator(".querychat-footer-buttons").wait_for(
-        state="visible", timeout=10_000
-    )
+    page.locator(".querychat-footer-buttons").wait_for(state="visible", timeout=10_000)
     # Wait for the chat input to re-enable — this signals the LLM turn is
     # complete and shinychat has finished its final re-render of the tool
     # result card.
@@ -99,7 +93,9 @@ class TestShowQueryToggle:
 
         expect(chevron).not_to_have_class("querychat-query-chevron--expanded")
         btn.click()
-        expect(chevron).to_have_class("querychat-query-chevron querychat-query-chevron--expanded")
+        expect(chevron).to_have_class(
+            "querychat-query-chevron querychat-query-chevron--expanded"
+        )
 
     def test_toggle_hides_section_again(self, page: Page) -> None:
         """Clicking the button a second time should hide the query section."""

--- a/pkg-py/tests/playwright/test_12_viz_bookmark.py
+++ b/pkg-py/tests/playwright/test_12_viz_bookmark.py
@@ -97,7 +97,9 @@ class TestVizBookmarkRestore:
 
     def _wait_for_viz_bookmark_url(self) -> str:
         """Wait for the bookmark URL to include the viz state."""
-        pre_search = self.pre_viz_url.split("?", 1)[1] if "?" in self.pre_viz_url else ""
+        pre_search = (
+            self.pre_viz_url.split("?", 1)[1] if "?" in self.pre_viz_url else ""
+        )
         self.page.wait_for_function(
             "(preSearch) => window.location.search.includes('_state_id_=') && window.location.search !== '?' + preSearch",
             arg=pre_search,
@@ -110,7 +112,9 @@ class TestVizBookmarkRestore:
         url = self._wait_for_viz_bookmark_url()
         assert url != self.pre_viz_url, "URL should have changed after viz bookmarking"
 
-    def test_viz_widget_renders_on_bookmark_restore(self, context: BrowserContext) -> None:
+    def test_viz_widget_renders_on_bookmark_restore(
+        self, context: BrowserContext
+    ) -> None:
         """BOOKMARK-VIZ-RESTORE: Restored bookmark should re-render the chart widget, not just the HTML shell."""
         bookmark_url = self._wait_for_viz_bookmark_url()
 

--- a/pkg-py/tests/test_base.py
+++ b/pkg-py/tests/test_base.py
@@ -293,23 +293,17 @@ class TestDataDict:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             QueryChat(df, table_name="t", data_description="some desc")
-        assert not any(issubclass(warning.category, DeprecationWarning) for warning in w)
+        assert not any(
+            issubclass(warning.category, DeprecationWarning) for warning in w
+        )
 
 
 @pytest.fixture
 def multi_table_engine():
     engine = create_engine("sqlite:///:memory:")
     with engine.connect() as conn:
-        conn.execute(
-            text(
-                "CREATE TABLE orders (id INTEGER PRIMARY KEY, amount REAL)"
-            )
-        )
-        conn.execute(
-            text(
-                "CREATE TABLE customers (id INTEGER PRIMARY KEY, name TEXT)"
-            )
-        )
+        conn.execute(text("CREATE TABLE orders (id INTEGER PRIMARY KEY, amount REAL)"))
+        conn.execute(text("CREATE TABLE customers (id INTEGER PRIMARY KEY, name TEXT)"))
         conn.execute(text("INSERT INTO orders VALUES (1, 99.99), (2, 49.50)"))
         conn.execute(text("INSERT INTO customers VALUES (1, 'Alice'), (2, 'Bob')"))
         conn.commit()
@@ -368,7 +362,8 @@ class TestAddTables:
             warnings.simplefilter("always")
             qc.add_tables(multi_table_engine)
         multi_table_warns = [
-            x for x in w
+            x
+            for x in w
             if issubclass(x.category, UserWarning)
             and "Multiple tables" in str(x.message)
         ]
@@ -437,7 +432,8 @@ class TestAddTablesIbis:
             warnings.simplefilter("always")
             qc.add_tables(ibis_backend_with_tables)
         multi_table_warns = [
-            x for x in w
+            x
+            for x in w
             if issubclass(x.category, UserWarning)
             and "Multiple tables" in str(x.message)
         ]

--- a/pkg-py/tests/test_base.py
+++ b/pkg-py/tests/test_base.py
@@ -17,6 +17,7 @@ from querychat._querychat_base import (
     create_client,
     normalize_data_source,
     normalize_tools,
+    resolve_client,
 )
 from querychat._shiny import QueryChat
 from querychat._utils import MISSING
@@ -113,28 +114,37 @@ class TestNormalizeDataSource:
         assert "column.with.dots" in schema
 
 
-class TestNormalizeClient:
+class TestResolveClient:
     def test_with_none_uses_default(self):
-        result = create_client(None)
+        result = resolve_client(None)
         assert isinstance(result, chatlas.Chat)
 
     def test_with_string_provider(self):
-        result = create_client("openai")
+        result = resolve_client("openai")
         assert isinstance(result, chatlas.Chat)
 
     def test_with_chat_instance(self):
         chat = chatlas.ChatOpenAI()
-        result = create_client(chat)
-        assert isinstance(result, chatlas.Chat)
+        result = resolve_client(chat)
+        assert result is chat
 
     def test_respects_env_variable(self, monkeypatch):
         monkeypatch.setenv("QUERYCHAT_CLIENT", "openai")
-        result = create_client(None)
+        result = resolve_client(None)
         assert isinstance(result, chatlas.Chat)
 
     def test_with_invalid_provider_raises(self):
         with pytest.raises(ValueError, match="is not a known chatlas provider"):
-            create_client("not_a_real_provider_xyz123")
+            resolve_client("not_a_real_provider_xyz123")
+
+
+class TestCreateClient:
+    def test_clones_chat(self):
+        chat = chatlas.ChatOpenAI()
+        result = create_client(chat)
+        assert isinstance(result, chatlas.Chat)
+        assert result is not chat
+        assert len(result.get_turns()) == 0
 
 
 class TestNormalizeTools:

--- a/pkg-py/tests/test_data_dict.py
+++ b/pkg-py/tests/test_data_dict.py
@@ -175,7 +175,7 @@ def test_get_table_schema_mixed_coverage() -> None:
     col_map = {c.name: c for c in cols}
     assert col_map["amount"].min_val == 0  # from data_dict
     assert col_map["amount"].max_val == 999
-    assert "status" in col_map            # from SQL fallback
+    assert "status" in col_map  # from SQL fallback
 
 
 def test_to_prompt_dict_excludes_column_specs() -> None:

--- a/pkg-py/tests/test_datasource.py
+++ b/pkg-py/tests/test_datasource.py
@@ -535,7 +535,9 @@ def test_column_meta_has_description_field() -> None:
 
 def test_format_schema_includes_description() -> None:
     cols = [
-        ColumnMeta(name="id", sql_type="INTEGER", kind="numeric", description="Primary key"),
+        ColumnMeta(
+            name="id", sql_type="INTEGER", kind="numeric", description="Primary key"
+        ),
         ColumnMeta(name="name", sql_type="TEXT", kind="text"),
     ]
     result = format_schema("mytable", cols)

--- a/pkg-py/tests/test_deferred_client.py
+++ b/pkg-py/tests/test_deferred_client.py
@@ -93,7 +93,9 @@ class TestDeferredClientIntegration:
         assert client is not None
         assert "users" in qc.system_prompt
 
-    def test_deferred_explicit_client_at_init_then_data_source(self, sample_df, monkeypatch):
+    def test_deferred_explicit_client_at_init_then_data_source(
+        self, sample_df, monkeypatch
+    ):
         """Test an explicit deferred client passed at init still works later."""
         monkeypatch.setenv("OPENAI_API_KEY", "sk-dummy-key-for-testing")
 
@@ -153,7 +155,9 @@ class TestPromptRebuildWarning:
         with pytest.warns(UserWarning, match="chat history"):
             qc.add_table(sample_df, "users")
 
-    def test_warns_when_console_client_has_history(self, sample_df, other_df, monkeypatch):
+    def test_warns_when_console_client_has_history(
+        self, sample_df, other_df, monkeypatch
+    ):
         monkeypatch.setenv("OPENAI_API_KEY", "sk-dummy-key-for-testing")
         qc = QueryChatBase(sample_df, "users")
 
@@ -164,9 +168,13 @@ class TestPromptRebuildWarning:
         with pytest.warns(UserWarning, match="chat history"):
             qc.add_table(other_df, "orders")
 
-    def test_no_warning_without_history(self, sample_df, other_df, recwarn, monkeypatch):
+    def test_no_warning_without_history(
+        self, sample_df, other_df, recwarn, monkeypatch
+    ):
         monkeypatch.setenv("OPENAI_API_KEY", "sk-dummy-key-for-testing")
         qc = QueryChatBase(sample_df, "users")
         qc.add_table(other_df, "orders")
-        chat_history_warnings = [w for w in recwarn.list if "chat history" in str(w.message)]
+        chat_history_warnings = [
+            w for w in recwarn.list if "chat history" in str(w.message)
+        ]
         assert len(chat_history_warnings) == 0

--- a/pkg-py/tests/test_deferred_client.py
+++ b/pkg-py/tests/test_deferred_client.py
@@ -1,5 +1,6 @@
 """Tests for deferred chat client initialization."""
 
+import chatlas
 import pandas as pd
 import pytest
 from chatlas import ChatOpenAI, Turn
@@ -22,31 +23,33 @@ class TestDeferredClientInit:
     """Tests for initializing QueryChatBase with deferred client."""
 
     def test_init_with_none_data_source_defers_client(self):
-        """When data_source is None and client is not provided, _client_spec should be None."""
+        """When data_source is None and client is not provided, _base_client should be None."""
         qc = QueryChatBase(None, "users")
-        assert qc._client_spec is None
+        assert qc._base_client is None
 
-    def test_init_with_explicit_client_and_none_data_source(self):
-        """When data_source is None but client is provided, _client_spec should be stored."""
+    def test_init_with_explicit_client_and_none_data_source(self, monkeypatch):
+        """When data_source is None but client is provided, _base_client should be resolved."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-dummy-key-for-testing")
         qc = QueryChatBase(None, "users", client="openai")
-        assert qc._client_spec == "openai"
+        assert isinstance(qc._base_client, chatlas.Chat)
 
     def test_init_with_chat_object_stores_spec(self, monkeypatch):
         """When a Chat object is passed, it should be stored as-is."""
         monkeypatch.setenv("OPENAI_API_KEY", "sk-dummy-key-for-testing")
         chat = ChatOpenAI()
         qc = QueryChatBase(None, "users", client=chat)
-        assert qc._client_spec is chat
+        assert qc._base_client is chat
 
     def test_init_with_data_source_no_client(self, sample_df):
-        """When data_source is provided without client, _client_spec should be None."""
+        """When data_source is provided without client, _base_client should be None."""
         qc = QueryChatBase(sample_df, "users")
-        assert qc._client_spec is None
+        assert qc._base_client is None
 
-    def test_init_with_invalid_explicit_client_is_still_lazy(self):
-        """Explicit client specs should be stored lazily and fail only when resolved."""
-        qc = QueryChatBase(None, "users", client="not_a_real_provider_xyz123")
-        assert qc._client_spec == "not_a_real_provider_xyz123"
+    def test_init_with_invalid_explicit_client_raises_immediately(self):
+        """Invalid explicit client specs should fail at init (fail-fast)."""
+        with pytest.raises(ValueError, match="is not a known chatlas provider"):
+            QueryChatBase(None, "users", client="not_a_real_provider_xyz123")
+
 
 class TestClientMethodRequirements:
     """Tests that methods properly require data_source to be set."""
@@ -82,7 +85,7 @@ class TestDeferredClientIntegration:
 
         qc = QueryChatBase(None, "users")
         assert len(qc.table_names()) == 0
-        assert qc._client_spec is None
+        assert qc._base_client is None
 
         qc.add_table(sample_df, "users")
 
@@ -106,15 +109,12 @@ class TestDeferredClientIntegration:
         monkeypatch.delenv("QUERYCHAT_CLIENT", raising=False)
 
         qc = QueryChatBase(None, "users")
-        assert qc._client_spec is None
+        assert qc._base_client is None
 
-    def test_invalid_explicit_client_raises_when_client_is_resolved(self, sample_df):
-        """Invalid explicit client specs should fail when a live client is requested."""
-        qc = QueryChatBase(None, "users", client="not_a_real_provider_xyz123")
-        qc.add_table(sample_df, "users")
-
+    def test_invalid_explicit_client_raises_when_client_is_resolved(self):
+        """Invalid explicit client specs should fail at init (fail-fast)."""
         with pytest.raises(ValueError, match="is not a known chatlas provider"):
-            qc.client()
+            QueryChatBase(None, "users", client="not_a_real_provider_xyz123")
 
 
 class TestBackwardCompatibility:
@@ -126,8 +126,7 @@ class TestBackwardCompatibility:
         qc = QueryChatBase(sample_df, "test_table")
 
         assert len(qc.table_names()) > 0
-        # _client_spec is None (will use env default at resolution time)
-        assert qc._client_spec is None
+        assert qc._base_client is None
 
         client = qc.client()
         assert client is not None
@@ -144,7 +143,7 @@ def other_df():
 class TestPromptRebuildWarning:
     """Warns when system prompt is rebuilt after a client already has chat history."""
 
-    def test_warns_when_client_spec_has_history(self, sample_df, monkeypatch):
+    def test_warns_when_base_client_has_history(self, sample_df, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "sk-dummy-key-for-testing")
         chat = ChatOpenAI()
         chat.set_turns([Turn(role="user", contents=["hello"])])

--- a/pkg-py/tests/test_deferred_datasource.py
+++ b/pkg-py/tests/test_deferred_datasource.py
@@ -131,7 +131,7 @@ class TestDeferredPatternIntegration:
     def test_deferred_then_add_table(self, sample_df):
         qc = QueryChatBase(None, "users")
         assert len(qc.table_names()) == 0
-        assert qc._client_spec is None
+        assert qc._base_client is None
 
         qc.add_table(sample_df, "users")
         assert len(qc.table_names()) > 0

--- a/pkg-py/tests/test_deferred_shiny.py
+++ b/pkg-py/tests/test_deferred_shiny.py
@@ -87,7 +87,7 @@ class TestShinyDeferredDataSource:
 
         assert qc is not None
 
-    def test_server_client_override_does_not_mutate_shared_client_spec(
+    def test_server_client_override_does_not_mutate_base_client(
         self, sample_df, monkeypatch
     ):
         """server(client=...) should stay lazy during the stub session."""
@@ -111,11 +111,11 @@ class TestShinyDeferredDataSource:
 
         assert isinstance(vals.client, chatlas.Chat)
         assert len(recorded_specs) == 1
-        assert recorded_specs[0] is override_client
-        assert qc._client_spec is init_client
+        assert isinstance(recorded_specs[0], chatlas.Chat)
+        assert qc._base_client is init_client
 
     def test_multiple_server_overrides_do_not_leak_into_shared_state(self, sample_df):
-        """Sequential overrides should not overwrite the instance-level client spec."""
+        """Sequential overrides should not overwrite the instance-level base client."""
         init_client = ChatOpenAI(model="gpt-4.1")
         first_override = ChatOpenAI(model="gpt-4.1-mini")
         second_override = ChatOpenAI(model="gpt-4.1-nano")
@@ -131,7 +131,7 @@ class TestShinyDeferredDataSource:
         with session_context(ExpressStubSession()):
             qc.server(client=second_override)
 
-        assert qc._client_spec is init_client
+        assert qc._base_client is init_client
 
 
 class TestExpressMultiTable:

--- a/pkg-py/tests/test_frameworks.py
+++ b/pkg-py/tests/test_frameworks.py
@@ -61,7 +61,9 @@ class TestGradioQueryChat:
         from querychat.gradio import QueryChat
 
         qc = QueryChat(pd.DataFrame({"id": [1, 2], "amount": [10, 20]}), "orders")
-        qc.add_table(pd.DataFrame({"id": [101, 102], "state": ["CA", "NY"]}), "customers")
+        qc.add_table(
+            pd.DataFrame({"id": [101, 102], "state": ["CA", "NY"]}), "customers"
+        )
 
         app = qc.app()._blocks
         update_displays = next(

--- a/pkg-py/tests/test_multi_table.py
+++ b/pkg-py/tests/test_multi_table.py
@@ -63,19 +63,23 @@ def shared_sqlite_engine():
     engine = create_engine(f"sqlite:///{temp_db.name}")
 
     with engine.begin() as conn:
-        conn.execute(text("""
+        conn.execute(
+            text("""
             CREATE TABLE orders (
                 id INTEGER,
                 customer_id INTEGER,
                 amount REAL
             )
-        """))
-        conn.execute(text("""
+        """)
+        )
+        conn.execute(
+            text("""
             CREATE TABLE customers (
                 id INTEGER,
                 name TEXT
             )
-        """))
+        """)
+        )
         conn.execute(
             text("""
                 INSERT INTO orders (id, customer_id, amount)
@@ -257,7 +261,6 @@ class TestTableAccessor:
     """Tests for table() method and TableAccessor class."""
 
 
-
 class TestMultiTableSystemPrompt:
     """Tests for multi-table system prompt generation."""
 
@@ -381,9 +384,7 @@ class TestSourceCompatibility:
         with pytest.raises(ValueError, match="share the same backend instance"):
             check_source_compatibility({"orders": first}, second, "customers")
 
-    def test_add_table_replace_validates_compatibility(
-        self, orders_qc, customers_df
-    ):
+    def test_add_table_replace_validates_compatibility(self, orders_qc, customers_df):
         """Replacing a table must still respect multi-table compatibility."""
         orders_qc.add_table(customers_df, "customers")
         original_orders = orders_qc._data_sources["orders"]
@@ -460,7 +461,9 @@ class TestBuildQueryExecutor:
         with pytest.raises(ValueError, match="same DataFrame backend"):
             orders_qc._build_query_executor()
 
-    def test_cached_executor_survives_direct_source_mutation(self, orders_qc, customers_df):
+    def test_cached_executor_survives_direct_source_mutation(
+        self, orders_qc, customers_df
+    ):
         """Executor built lazily is not invalidated by direct _data_sources mutation."""
         orders_qc.add_table(customers_df, "customers")
         built = orders_qc._require_query_executor("test")
@@ -500,6 +503,7 @@ class TestBuildQueryExecutor:
             "querychat._querychat_base.normalize_data_source",
             capture_staged_source,
         )
+
         def fail_compat(*a, **kw):
             raise ValueError("compat check failed")
 
@@ -537,6 +541,7 @@ class TestBuildQueryExecutor:
             "querychat._querychat_base.normalize_data_source",
             capture_staged_source,
         )
+
         def fail_compat(*a, **kw):
             raise ValueError("compat check failed")
 
@@ -605,8 +610,12 @@ class TestMultiTableGuardrails:
             sql=_MultiTableWarnReactive(orders_sql, "sql", "orders", table_list),  # type: ignore[arg-type]
             title=_MultiTableWarnReactive(orders_title, "title", "orders", table_list),  # type: ignore[arg-type]
             tables={
-                "orders": TableState(sql=orders_sql, title=orders_title, df=lambda: orders_df),
-                "customers": TableState(sql=customers_sql, title=customers_title, df=lambda: customers_df),
+                "orders": TableState(
+                    sql=orders_sql, title=orders_title, df=lambda: orders_df
+                ),
+                "customers": TableState(
+                    sql=customers_sql, title=customers_title, df=lambda: customers_df
+                ),
             },
             client=None,  # type: ignore[arg-type]
             data_sources={},
@@ -652,8 +661,12 @@ class TestMultiTableGuardrails:
             sql=_MultiTableWarnReactive(orders_sql, "sql", "orders", table_list),  # type: ignore[arg-type]
             title=_MultiTableWarnReactive(orders_title, "title", "orders", table_list),  # type: ignore[arg-type]
             tables={
-                "orders": TableState(sql=orders_sql, title=orders_title, df=lambda: orders_df),
-                "customers": TableState(sql=customers_sql, title=customers_title, df=lambda: customers_df),
+                "orders": TableState(
+                    sql=orders_sql, title=orders_title, df=lambda: orders_df
+                ),
+                "customers": TableState(
+                    sql=customers_sql, title=customers_title, df=lambda: customers_df
+                ),
             },
             client=None,  # type: ignore[arg-type]
             data_sources={},
@@ -680,11 +693,23 @@ class TestMultiTableGuardrails:
         table_list = "'orders', 'customers'"
         vals = ServerValues(
             df=lambda: None,  # type: ignore[return-value]
-            sql=_MultiTableWarnReactive(reactive.Value(None), "sql", "orders", table_list),  # type: ignore[arg-type]
-            title=_MultiTableWarnReactive(reactive.Value(None), "title", "orders", table_list),  # type: ignore[arg-type]
+            sql=_MultiTableWarnReactive(
+                reactive.Value(None), "sql", "orders", table_list
+            ),  # type: ignore[arg-type]
+            title=_MultiTableWarnReactive(
+                reactive.Value(None), "title", "orders", table_list
+            ),  # type: ignore[arg-type]
             tables={
-                "orders": TableState(sql=reactive.Value(None), title=reactive.Value(None), df=lambda: orders_df),
-                "customers": TableState(sql=reactive.Value(None), title=reactive.Value(None), df=lambda: customers_df),
+                "orders": TableState(
+                    sql=reactive.Value(None),
+                    title=reactive.Value(None),
+                    df=lambda: orders_df,
+                ),
+                "customers": TableState(
+                    sql=reactive.Value(None),
+                    title=reactive.Value(None),
+                    df=lambda: customers_df,
+                ),
             },
             client=None,  # type: ignore[arg-type]
             data_sources={"orders": orders_source, "customers": customers_source},
@@ -707,8 +732,16 @@ class TestMultiTableGuardrails:
             sql=reactive.Value(None),
             title=reactive.Value(None),
             tables={
-                "orders": TableState(sql=reactive.Value(None), title=reactive.Value(None), df=lambda: orders_df),
-                "customers": TableState(sql=reactive.Value(None), title=reactive.Value(None), df=lambda: customers_df),
+                "orders": TableState(
+                    sql=reactive.Value(None),
+                    title=reactive.Value(None),
+                    df=lambda: orders_df,
+                ),
+                "customers": TableState(
+                    sql=reactive.Value(None),
+                    title=reactive.Value(None),
+                    df=lambda: customers_df,
+                ),
             },
             client=None,  # type: ignore[arg-type]
             data_sources={"orders": orders_source, "customers": customers_source},
@@ -735,7 +768,11 @@ class TestMultiTableGuardrails:
             sql=reactive.Value(None),
             title=reactive.Value(None),
             tables={
-                "orders": TableState(sql=reactive.Value(None), title=reactive.Value(None), df=lambda: orders_df),
+                "orders": TableState(
+                    sql=reactive.Value(None),
+                    title=reactive.Value(None),
+                    df=lambda: orders_df,
+                ),
             },
             client=None,  # type: ignore[arg-type]
             data_sources={"orders": orders_source},
@@ -769,7 +806,9 @@ class TestMultiTableGuardrails:
         with reactive.isolate():
             assert vals.current_table() is None
 
-    def test_server_values_current_table_reflects_reactive(self, orders_df, customers_df):
+    def test_server_values_current_table_reflects_reactive(
+        self, orders_df, customers_df
+    ):
         from querychat._shiny_module import (
             ServerValues,
             TableState,
@@ -782,11 +821,23 @@ class TestMultiTableGuardrails:
         table_list = "'orders', 'customers'"
         vals = ServerValues(
             df=lambda: None,  # type: ignore[return-value]
-            sql=_MultiTableWarnReactive(reactive.Value(None), "sql", "orders", table_list),  # type: ignore[arg-type]
-            title=_MultiTableWarnReactive(reactive.Value(None), "title", "orders", table_list),  # type: ignore[arg-type]
+            sql=_MultiTableWarnReactive(
+                reactive.Value(None), "sql", "orders", table_list
+            ),  # type: ignore[arg-type]
+            title=_MultiTableWarnReactive(
+                reactive.Value(None), "title", "orders", table_list
+            ),  # type: ignore[arg-type]
             tables={
-                "orders": TableState(sql=reactive.Value(None), title=reactive.Value(None), df=lambda: orders_df),
-                "customers": TableState(sql=reactive.Value(None), title=reactive.Value(None), df=lambda: customers_df),
+                "orders": TableState(
+                    sql=reactive.Value(None),
+                    title=reactive.Value(None),
+                    df=lambda: orders_df,
+                ),
+                "customers": TableState(
+                    sql=reactive.Value(None),
+                    title=reactive.Value(None),
+                    df=lambda: customers_df,
+                ),
             },
             client=None,  # type: ignore[arg-type]
             data_sources={},
@@ -922,7 +973,9 @@ class TestMultiTableGuardrails:
             "title": None,
             "error": None,
             "table": "orders",
-            "table_states": {"orders": {"sql": "SELECT 1", "title": None, "error": None}},
+            "table_states": {
+                "orders": {"sql": "SELECT 1", "title": None, "error": None}
+            },
             "turns": [],
         }
         with pytest.warns(FutureWarning, match="multiple tables"):
@@ -959,14 +1012,18 @@ class TestMultiTableGuardrails:
             "title": None,
             "error": None,
             "table": "orders",
-            "table_states": {"orders": {"sql": None, "title": "Big orders", "error": None}},
+            "table_states": {
+                "orders": {"sql": None, "title": "Big orders", "error": None}
+            },
             "turns": [],
         }
         with pytest.warns(FutureWarning, match="multiple tables"):
             result = acc.title(state)
         assert result == "Big orders"
 
-    def test_state_dict_mixin_with_table_kwarg_still_works(self, orders_df, customers_df):
+    def test_state_dict_mixin_with_table_kwarg_still_works(
+        self, orders_df, customers_df
+    ):
         from unittest.mock import MagicMock
 
         from querychat import QueryChat
@@ -996,7 +1053,10 @@ class TestMultiTableGuardrails:
                 "orders": {"sql": None, "title": None, "error": None},
                 "customers": {"sql": None, "title": None, "error": None},
             },
-            "sql": None, "title": None, "error": None, "turns": [],
+            "sql": None,
+            "title": None,
+            "error": None,
+            "turns": [],
         }
         assert acc.sql(state, table="orders") is None
         assert acc.title(state, table="orders") is None
@@ -1020,7 +1080,9 @@ class TestMultiTableQueryTool:
         ):
             qc.client(tools="query")
 
-        query_tool = next(tool for tool in registered_tools if tool.name == "querychat_query")
+        query_tool = next(
+            tool for tool in registered_tools if tool.name == "querychat_query"
+        )
         result = query_tool.func(
             """
             SELECT customers.name, orders.amount
@@ -1064,9 +1126,7 @@ class TestDataDictListInput:
         qc = QueryChat(orders_df, "orders", data_dict=dd)
         assert qc is not None
 
-    def test_list_dicts_appear_in_system_prompt(
-        self, orders_df, customers_df
-    ) -> None:
+    def test_list_dicts_appear_in_system_prompt(self, orders_df, customers_df) -> None:
         from querychat._data_dict import DataDict, TableSpec
 
         dd1 = DataDict(name="sales", tables={"orders": TableSpec(description="Orders")})

--- a/pkg-py/tests/test_multi_table_frameworks.py
+++ b/pkg-py/tests/test_multi_table_frameworks.py
@@ -25,7 +25,9 @@ def orders_df():
 
 @pytest.fixture
 def customers_df():
-    return pd.DataFrame({"id": [101, 102], "name": ["Alice", "Bob"], "state": ["CA", "NY"]})
+    return pd.DataFrame(
+        {"id": [101, 102], "name": ["Alice", "Bob"], "state": ["CA", "NY"]}
+    )
 
 
 class TestStreamlitMultiTable:
@@ -82,7 +84,9 @@ class TestStreamlitMultiTable:
         fake_session = {}
         with patch("streamlit.session_state", fake_session):
             state = qc._get_state()
-            state._table_states["orders"]["sql"] = "SELECT * FROM orders WHERE amount > 100"
+            state._table_states["orders"]["sql"] = (
+                "SELECT * FROM orders WHERE amount > 100"
+            )
             state._table_states["orders"]["title"] = "Big orders"
             assert qc.table("orders").sql() == "SELECT * FROM orders WHERE amount > 100"
             assert qc.table("orders").title() == "Big orders"
@@ -225,5 +229,3 @@ class TestStateDictQueryChatMultiTable:
         with pytest.warns(FutureWarning, match="multiple tables"):
             result = acc.title(state)
         assert result == "Big orders"
-
-

--- a/pkg-py/tests/test_pin_source.py
+++ b/pkg-py/tests/test_pin_source.py
@@ -96,7 +96,9 @@ class TestPinSourceSchema:
         assert lines[1] == "Columns:"
 
     def test_get_schema_categorical_values(self, board):
-        df = pd.DataFrame({"category": ["A", "B", "A", "C", "B"], "value": [1, 2, 3, 4, 5]})
+        df = pd.DataFrame(
+            {"category": ["A", "B", "A", "C", "B"], "value": [1, 2, 3, 4, 5]}
+        )
         board.pin_write(df, "cat_test", type="parquet")
         ps = PinSource(board, "cat_test")
         try:
@@ -200,9 +202,7 @@ class TestPinSourceErrors:
 
 class TestPinSourceSecurity:
     def test_duckdb_locked_down(self, parquet_source):
-        with pytest.raises(
-            duckdb.PermissionException, match="has been disabled"
-        ):
+        with pytest.raises(duckdb.PermissionException, match="has been disabled"):
             parquet_source.execute_query("SELECT * FROM read_csv_auto('/etc/passwd')")
 
     def test_blocks_unsafe_queries(self, parquet_source):
@@ -217,8 +217,11 @@ class TestQueryChatPinSourceIntegration:
         from querychat import QueryChat
 
         board.pin_write(
-            sample_df, "cars", type="parquet",
-            title="Motor Trend Cars", description="Road test data",
+            sample_df,
+            "cars",
+            type="parquet",
+            title="Motor Trend Cars",
+            description="Road test data",
         )
         ps = PinSource(board, "cars")
         qc = QueryChat(data_source=ps, table_name="cars", greeting="Hi")
@@ -233,11 +236,16 @@ class TestQueryChatPinSourceIntegration:
         from querychat import QueryChat
 
         board.pin_write(
-            sample_df, "cars", type="parquet", title="Motor Trend Cars",
+            sample_df,
+            "cars",
+            type="parquet",
+            title="Motor Trend Cars",
         )
         ps = PinSource(board, "cars")
         qc = QueryChat(
-            data_source=ps, table_name="cars", greeting="Hi",
+            data_source=ps,
+            table_name="cars",
+            greeting="Hi",
             data_description="Custom description",
         )
         try:
@@ -251,11 +259,16 @@ class TestQueryChatPinSourceIntegration:
         from querychat import QueryChat
 
         board.pin_write(
-            sample_df, "cars", type="parquet", title="Motor Trend Cars",
+            sample_df,
+            "cars",
+            type="parquet",
+            title="Motor Trend Cars",
         )
         ps = PinSource(board, "cars")
         qc = QueryChat(
-            data_source=ps, table_name="cars", greeting="Hi",
+            data_source=ps,
+            table_name="cars",
+            greeting="Hi",
             data_description="Custom description",
         )
         try:
@@ -270,7 +283,10 @@ class TestQueryChatPinSourceIntegration:
         from querychat import QueryChat
 
         board.pin_write(
-            sample_df, "cars", type="parquet", title="Motor Trend Cars",
+            sample_df,
+            "cars",
+            type="parquet",
+            title="Motor Trend Cars",
         )
         ps = PinSource(board, "cars")
         qc = QueryChat(data_source=ps, table_name="cars", greeting="Hi")

--- a/pkg-py/tests/test_query_executor.py
+++ b/pkg-py/tests/test_query_executor.py
@@ -24,20 +24,24 @@ from sqlalchemy import create_engine, text
 
 @pytest.fixture
 def orders_source():
-    df = pd.DataFrame({
-        "order_id": [1, 2, 3],
-        "customer_id": [10, 20, 10],
-        "amount": [100.0, 200.0, 150.0],
-    })
+    df = pd.DataFrame(
+        {
+            "order_id": [1, 2, 3],
+            "customer_id": [10, 20, 10],
+            "amount": [100.0, 200.0, 150.0],
+        }
+    )
     return DataFrameSource(nw.from_native(df), "orders")
 
 
 @pytest.fixture
 def customers_source():
-    df = pd.DataFrame({
-        "id": [10, 20, 30],
-        "name": ["Alice", "Bob", "Charlie"],
-    })
+    df = pd.DataFrame(
+        {
+            "id": [10, 20, 30],
+            "name": ["Alice", "Bob", "Charlie"],
+        }
+    )
     return DataFrameSource(nw.from_native(df), "customers")
 
 
@@ -48,19 +52,23 @@ def sqlite_sources():
     engine = create_engine(f"sqlite:///{temp_db.name}")
 
     with engine.begin() as conn:
-        conn.execute(text("""
+        conn.execute(
+            text("""
             CREATE TABLE orders (
                 order_id INTEGER,
                 customer_id INTEGER,
                 amount REAL
             )
-        """))
-        conn.execute(text("""
+        """)
+        )
+        conn.execute(
+            text("""
             CREATE TABLE customers (
                 id INTEGER,
                 name TEXT
             )
-        """))
+        """)
+        )
         conn.execute(
             text("""
                 INSERT INTO orders (order_id, customer_id, amount)
@@ -119,20 +127,24 @@ def ibis_sources():
 
 @pytest.fixture
 def orders_polars_dataframe_source():
-    df = pl.DataFrame({
-        "order_id": [1, 2, 3],
-        "customer_id": [10, 20, 10],
-        "amount": [100.0, 200.0, 150.0],
-    })
+    df = pl.DataFrame(
+        {
+            "order_id": [1, 2, 3],
+            "customer_id": [10, 20, 10],
+            "amount": [100.0, 200.0, 150.0],
+        }
+    )
     return DataFrameSource(nw.from_native(df), "orders_polars")
 
 
 class TestDuckDBExecutor:
     def test_cross_table_join(self, orders_source, customers_source):
-        executor = DuckDBExecutor({
-            "orders": orders_source,
-            "customers": customers_source,
-        })
+        executor = DuckDBExecutor(
+            {
+                "orders": orders_source,
+                "customers": customers_source,
+            }
+        )
         result = executor.execute_query(
             "SELECT o.order_id, c.name "
             "FROM orders o JOIN customers c ON o.customer_id = c.id"
@@ -143,10 +155,12 @@ class TestDuckDBExecutor:
         executor.cleanup()
 
     def test_single_table_query(self, orders_source, customers_source):
-        executor = DuckDBExecutor({
-            "orders": orders_source,
-            "customers": customers_source,
-        })
+        executor = DuckDBExecutor(
+            {
+                "orders": orders_source,
+                "customers": customers_source,
+            }
+        )
         result = executor.execute_query("SELECT * FROM orders WHERE amount > 100")
         nw_df = nw.from_native(result, eager_only=True)
         assert nw_df.shape[0] == 2
@@ -183,10 +197,12 @@ class TestDuckDBExecutor:
         executor.cleanup()
 
     def test_test_query_cross_table_join(self, orders_source, customers_source):
-        executor = DuckDBExecutor({
-            "orders": orders_source,
-            "customers": customers_source,
-        })
+        executor = DuckDBExecutor(
+            {
+                "orders": orders_source,
+                "customers": customers_source,
+            }
+        )
         executor.test_query(
             "SELECT o.* FROM orders o "
             "JOIN customers c ON o.customer_id = c.id "
@@ -214,10 +230,12 @@ class TestDuckDBExecutor:
         self, orders_source, orders_polars_dataframe_source
     ):
         with pytest.raises(ValueError, match="same DataFrame backend"):
-            DuckDBExecutor({
-                "orders": orders_source,
-                "orders_polars": orders_polars_dataframe_source,
-            })
+            DuckDBExecutor(
+                {
+                    "orders": orders_source,
+                    "orders_polars": orders_polars_dataframe_source,
+                }
+            )
 
     def test_rejects_mixed_dataframe_backends_before_opening_connection(
         self, monkeypatch, orders_source, orders_polars_dataframe_source
@@ -225,40 +243,50 @@ class TestDuckDBExecutor:
         def fail_if_connect_called(*args, **kwargs):
             raise AssertionError("duckdb.connect should not be called")
 
-        monkeypatch.setattr("querychat._query_executor.duckdb.connect", fail_if_connect_called)
+        monkeypatch.setattr(
+            "querychat._query_executor.duckdb.connect", fail_if_connect_called
+        )
 
         with pytest.raises(ValueError, match="same DataFrame backend"):
-            DuckDBExecutor({
-                "orders": orders_source,
-                "orders_polars": orders_polars_dataframe_source,
-            })
+            DuckDBExecutor(
+                {
+                    "orders": orders_source,
+                    "orders_polars": orders_polars_dataframe_source,
+                }
+            )
 
 
 @pytest.fixture
 def orders_polars_source():
-    lf = pl.LazyFrame({
-        "order_id": [1, 2, 3],
-        "customer_id": [10, 20, 10],
-        "amount": [100.0, 200.0, 150.0],
-    })
+    lf = pl.LazyFrame(
+        {
+            "order_id": [1, 2, 3],
+            "customer_id": [10, 20, 10],
+            "amount": [100.0, 200.0, 150.0],
+        }
+    )
     return PolarsLazySource(nw.from_native(lf), "orders")
 
 
 @pytest.fixture
 def customers_polars_source():
-    lf = pl.LazyFrame({
-        "id": [10, 20, 30],
-        "name": ["Alice", "Bob", "Charlie"],
-    })
+    lf = pl.LazyFrame(
+        {
+            "id": [10, 20, 30],
+            "name": ["Alice", "Bob", "Charlie"],
+        }
+    )
     return PolarsLazySource(nw.from_native(lf), "customers")
 
 
 class TestPolarsSQLExecutor:
     def test_cross_table_join(self, orders_polars_source, customers_polars_source):
-        executor = PolarsSQLExecutor({
-            "orders": orders_polars_source,
-            "customers": customers_polars_source,
-        })
+        executor = PolarsSQLExecutor(
+            {
+                "orders": orders_polars_source,
+                "customers": customers_polars_source,
+            }
+        )
         result = executor.execute_query(
             "SELECT o.order_id, c.name "
             "FROM orders o JOIN customers c ON o.customer_id = c.id"
@@ -298,10 +326,12 @@ class TestDataSourceExecutor:
         assert executor.get_db_type() == "DuckDB"
 
     def test_test_query_routes_by_table(self, orders_source, customers_source):
-        executor = DataSourceExecutor({
-            "orders": orders_source,
-            "customers": customers_source,
-        })
+        executor = DataSourceExecutor(
+            {
+                "orders": orders_source,
+                "customers": customers_source,
+            }
+        )
         # test_query against orders — should check orders columns
         with pytest.raises(MissingColumnsError, match="missing required columns"):
             executor.test_query(
@@ -350,10 +380,12 @@ class TestDataSourceExecutor:
                 )
 
             with pytest.raises(ValueError, match="share the same Engine instance"):
-                DataSourceExecutor({
-                    "orders": SQLAlchemySource(orders_engine, "orders"),
-                    "customers": SQLAlchemySource(customers_engine, "customers"),
-                })
+                DataSourceExecutor(
+                    {
+                        "orders": SQLAlchemySource(orders_engine, "orders"),
+                        "customers": SQLAlchemySource(customers_engine, "customers"),
+                    }
+                )
         finally:
             orders_engine.dispose()
             customers_engine.dispose()
@@ -380,10 +412,14 @@ class TestDataSourceExecutor:
             customers_conn.create_table("customers", {"id": [10], "name": ["Alice"]})
 
             with pytest.raises(ValueError, match="share the same backend instance"):
-                DataSourceExecutor({
-                    "orders": IbisSource(orders_conn.table("orders"), "orders"),
-                    "customers": IbisSource(customers_conn.table("customers"), "customers"),
-                })
+                DataSourceExecutor(
+                    {
+                        "orders": IbisSource(orders_conn.table("orders"), "orders"),
+                        "customers": IbisSource(
+                            customers_conn.table("customers"), "customers"
+                        ),
+                    }
+                )
         finally:
             orders_conn.disconnect()
             customers_conn.disconnect()

--- a/pkg-py/tests/test_querychat.py
+++ b/pkg-py/tests/test_querychat.py
@@ -300,6 +300,18 @@ def test_add_tables_include_in_greeting_invalid_type(sqlite_engine):
         qc.add_tables(sqlite_engine, include_in_greeting=1)  # type: ignore[arg-type]
 
 
+def test_add_tables_invalid_greeting_leaves_state_unchanged(sqlite_engine):
+    """A rejected include_in_greeting must not register any tables."""
+    qc = QueryChat()
+    with pytest.raises(TypeError, match="include_in_greeting"):
+        qc.add_tables(sqlite_engine, include_in_greeting=1)  # type: ignore[arg-type]
+    assert qc._data_sources == {}
+    assert qc.greeter.tables == []
+    # A subsequent valid call still succeeds (no half-registered tables).
+    qc.add_tables(sqlite_engine, include_in_greeting=True)
+    assert set(qc.greeter.tables) == {"orders", "customers"}
+
+
 def test_greeting_prompt_omits_dicts_for_excluded_tables(sqlite_engine, tmp_path):
     """A dict describing only excluded tables is dropped from the greeting prompt."""
     orders_yaml = tmp_path / "orders.yaml"

--- a/pkg-py/tests/test_querychat.py
+++ b/pkg-py/tests/test_querychat.py
@@ -334,6 +334,32 @@ def test_greeting_prompt_omits_dicts_for_excluded_tables(sqlite_engine, tmp_path
     assert "CUSTOMERS_DICT_DESC" not in prompt
 
 
+def test_greeting_prompt_keeps_global_dict_desc_drops_global_fields(
+    sqlite_engine, tmp_path
+):
+    """A table-less dict keeps its description; relationships/glossary are dropped."""
+    global_yaml = tmp_path / "global.yaml"
+    global_yaml.write_text(
+        "name: domain\ndescription: GLOBAL_DOMAIN_DESC\nglossary:\n  ARR: GLOSSARY_ARR_DEF\n"
+    )
+    orders_yaml = tmp_path / "orders.yaml"
+    orders_yaml.write_text(
+        "name: orders_dict\ndescription: ORDERS_DICT_DESC\n"
+        "tables:\n  orders:\n    description: Orders info\n"
+        "relationships:\n  - join: orders.id = customers.id\n    description: REL_DESC\n"
+    )
+
+    qc = QueryChat(data_dict=[str(global_yaml), str(orders_yaml)])
+    qc.add_tables(sqlite_engine, include_in_greeting="orders")
+
+    prompt = qc._build_greeting_client().system_prompt
+    assert prompt is not None
+    assert "GLOBAL_DOMAIN_DESC" in prompt
+    assert "ORDERS_DICT_DESC" in prompt
+    assert "GLOSSARY_ARR_DEF" not in prompt
+    assert "REL_DESC" not in prompt
+
+
 def test_generate_greeting_sets_greeting_and_returns_text(sample_df):
     """generate_greeting() returns the mocked text and sets qc.greeting."""
     qc = QueryChat(data_source=sample_df, table_name="test_table")

--- a/pkg-py/tests/test_querychat.py
+++ b/pkg-py/tests/test_querychat.py
@@ -346,8 +346,24 @@ def test_generate_greeting_with_empty_tables(sample_df):
     qc = QueryChat(data_source=sample_df, table_name="test_table")
     qc.greeter.tables = []
 
+    prompt = qc._build_greeting_client().system_prompt
+    assert prompt is not None
+    assert "following tables" not in prompt
+    assert "SQL SQL" not in prompt
+
     with patch("chatlas.Chat.chat", return_value="Generic greeting"):
         result = qc.generate_greeting()
 
     assert result == "Generic greeting"
     assert qc.greeting == "Generic greeting"
+
+
+def test_remove_table_prunes_greeter_tables(sqlite_engine):
+    """remove_table drops the removed name from greeter.tables."""
+    qc = QueryChat()
+    qc.add_tables(sqlite_engine, include_in_greeting=True)
+    assert "orders" in qc.greeter.tables
+
+    qc.remove_table("orders")
+    assert "orders" not in qc.greeter.tables
+    assert "customers" in qc.greeter.tables

--- a/pkg-py/tests/test_querychat.py
+++ b/pkg-py/tests/test_querychat.py
@@ -334,7 +334,7 @@ def test_greeting_prompt_omits_dicts_for_excluded_tables(sqlite_engine, tmp_path
     qc = QueryChat(data_dict=[str(orders_yaml), str(customers_yaml)])
     qc.add_tables(sqlite_engine, include_in_greeting=["orders"])
 
-    prompt = qc._build_greeting_client().system_prompt
+    prompt = qc.greeter.build_client().system_prompt
     assert prompt is not None
     assert "ORDERS_DICT_DESC" in prompt
     assert "CUSTOMERS_DICT_DESC" not in prompt
@@ -358,7 +358,7 @@ def test_greeting_prompt_keeps_global_dict_desc_drops_global_fields(
     qc = QueryChat(data_dict=[str(global_yaml), str(orders_yaml)])
     qc.add_tables(sqlite_engine, include_in_greeting=["orders"])
 
-    prompt = qc._build_greeting_client().system_prompt
+    prompt = qc.greeter.build_client().system_prompt
     assert prompt is not None
     assert "GLOBAL_DOMAIN_DESC" in prompt
     assert "ORDERS_DICT_DESC" in prompt
@@ -390,7 +390,7 @@ def test_generate_greeting_with_empty_tables(sample_df):
     qc = QueryChat(data_source=sample_df, table_name="test_table")
     qc.greeter.tables = []
 
-    prompt = qc._build_greeting_client().system_prompt
+    prompt = qc.greeter.build_client().system_prompt
     assert prompt is not None
     assert "following tables" not in prompt
     assert "SQL SQL" not in prompt
@@ -408,10 +408,12 @@ def test_greeting_prompt_keeps_global_dict_desc_with_no_tables(sample_df, tmp_pa
     global_yaml.write_text(
         "name: domain\ndescription: GLOBAL_DOMAIN_DESC\nglossary:\n  ARR: GLOSSARY_ARR_DEF\n"
     )
-    qc = QueryChat(data_source=sample_df, table_name="test_table", data_dict=str(global_yaml))
+    qc = QueryChat(
+        data_source=sample_df, table_name="test_table", data_dict=str(global_yaml)
+    )
     qc.greeter.tables = []
 
-    prompt = qc._build_greeting_client().system_prompt
+    prompt = qc.greeter.build_client().system_prompt
     assert prompt is not None
     assert "GLOBAL_DOMAIN_DESC" in prompt
     assert "GLOSSARY_ARR_DEF" not in prompt

--- a/pkg-py/tests/test_querychat.py
+++ b/pkg-py/tests/test_querychat.py
@@ -238,6 +238,13 @@ def test_constructor_greeting_survives_greeter_mutations(sample_df):
     assert qc.greeting == "Hello!"
 
 
+def test_greeter_tables_setter_rejects_bare_string(sample_df):
+    """Assigning a bare string to greeter.tables raises instead of char-iterating."""
+    qc = QueryChat(data_source=sample_df, table_name="test_table")
+    with pytest.raises(TypeError, match="list of table names"):
+        qc.greeter.tables = "test_table"  # type: ignore[assignment]
+
+
 def test_add_table_include_in_greeting(sample_df):
     """add_table with include_in_greeting=True adds the name; default False does not."""
     qc = QueryChat()
@@ -285,16 +292,15 @@ def test_add_tables_include_in_greeting_list(sqlite_engine):
     assert "customers" not in qc.greeter.tables
 
 
-def test_add_tables_include_in_greeting_str(sqlite_engine):
-    """add_tables accepts a bare table-name string (parity with R)."""
+def test_add_tables_include_in_greeting_str_rejected(sqlite_engine):
+    """add_tables rejects a bare string; a list of names is required."""
     qc = QueryChat()
-    qc.add_tables(sqlite_engine, include_in_greeting="orders")
-    assert "orders" in qc.greeter.tables
-    assert "customers" not in qc.greeter.tables
+    with pytest.raises(TypeError, match="include_in_greeting"):
+        qc.add_tables(sqlite_engine, include_in_greeting="orders")  # type: ignore[arg-type]
 
 
 def test_add_tables_include_in_greeting_invalid_type(sqlite_engine):
-    """add_tables rejects non-bool, non-string include_in_greeting."""
+    """add_tables rejects non-bool, non-list include_in_greeting."""
     qc = QueryChat()
     with pytest.raises(TypeError, match="include_in_greeting"):
         qc.add_tables(sqlite_engine, include_in_greeting=1)  # type: ignore[arg-type]
@@ -326,7 +332,7 @@ def test_greeting_prompt_omits_dicts_for_excluded_tables(sqlite_engine, tmp_path
     )
 
     qc = QueryChat(data_dict=[str(orders_yaml), str(customers_yaml)])
-    qc.add_tables(sqlite_engine, include_in_greeting="orders")
+    qc.add_tables(sqlite_engine, include_in_greeting=["orders"])
 
     prompt = qc._build_greeting_client().system_prompt
     assert prompt is not None
@@ -350,7 +356,7 @@ def test_greeting_prompt_keeps_global_dict_desc_drops_global_fields(
     )
 
     qc = QueryChat(data_dict=[str(global_yaml), str(orders_yaml)])
-    qc.add_tables(sqlite_engine, include_in_greeting="orders")
+    qc.add_tables(sqlite_engine, include_in_greeting=["orders"])
 
     prompt = qc._build_greeting_client().system_prompt
     assert prompt is not None

--- a/pkg-py/tests/test_querychat.py
+++ b/pkg-py/tests/test_querychat.py
@@ -278,6 +278,21 @@ def test_add_tables_include_in_greeting_list(sqlite_engine):
     assert "customers" not in qc.greeter.tables
 
 
+def test_add_tables_include_in_greeting_str(sqlite_engine):
+    """add_tables accepts a bare table-name string (parity with R)."""
+    qc = QueryChat()
+    qc.add_tables(sqlite_engine, include_in_greeting="orders")
+    assert "orders" in qc.greeter.tables
+    assert "customers" not in qc.greeter.tables
+
+
+def test_add_tables_include_in_greeting_invalid_type(sqlite_engine):
+    """add_tables rejects non-bool, non-string include_in_greeting."""
+    qc = QueryChat()
+    with pytest.raises(TypeError, match="include_in_greeting"):
+        qc.add_tables(sqlite_engine, include_in_greeting=1)  # type: ignore[arg-type]
+
+
 def test_generate_greeting_sets_greeting_and_returns_text(sample_df):
     """generate_greeting() returns the mocked text and sets qc.greeting."""
     qc = QueryChat(data_source=sample_df, table_name="test_table")

--- a/pkg-py/tests/test_querychat.py
+++ b/pkg-py/tests/test_querychat.py
@@ -254,6 +254,13 @@ def test_add_table_include_in_greeting(sample_df):
     assert "base_table" not in qc.greeter.tables
 
 
+def test_add_table_include_in_greeting_invalid_type(sample_df):
+    """add_table rejects non-bool include_in_greeting."""
+    qc = QueryChat()
+    with pytest.raises(TypeError, match="include_in_greeting"):
+        qc.add_table(sample_df, "base_table", include_in_greeting="yes")  # type: ignore[arg-type]
+
+
 def test_add_tables_include_in_greeting_true(sqlite_engine):
     """add_tables with include_in_greeting=True adds all tables to greeter."""
     qc = QueryChat()

--- a/pkg-py/tests/test_querychat.py
+++ b/pkg-py/tests/test_querychat.py
@@ -396,6 +396,22 @@ def test_generate_greeting_with_empty_tables(sample_df):
     assert qc.greeting == "Generic greeting"
 
 
+def test_greeting_prompt_keeps_global_dict_desc_with_no_tables(sample_df, tmp_path):
+    """A global dict description renders even in a table-less generic greeting."""
+    global_yaml = tmp_path / "global.yaml"
+    global_yaml.write_text(
+        "name: domain\ndescription: GLOBAL_DOMAIN_DESC\nglossary:\n  ARR: GLOSSARY_ARR_DEF\n"
+    )
+    qc = QueryChat(data_source=sample_df, table_name="test_table", data_dict=str(global_yaml))
+    qc.greeter.tables = []
+
+    prompt = qc._build_greeting_client().system_prompt
+    assert prompt is not None
+    assert "GLOBAL_DOMAIN_DESC" in prompt
+    assert "GLOSSARY_ARR_DEF" not in prompt
+    assert "following tables" not in prompt
+
+
 def test_remove_table_prunes_greeter_tables(sqlite_engine):
     """remove_table drops the removed name from greeter.tables."""
     qc = QueryChat()

--- a/pkg-py/tests/test_querychat.py
+++ b/pkg-py/tests/test_querychat.py
@@ -1,4 +1,6 @@
 import os
+import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import ibis
@@ -7,6 +9,7 @@ import polars as pl
 import pytest
 from querychat import QueryChat
 from querychat._datasource import IbisSource, PolarsLazySource
+from sqlalchemy import create_engine, text
 
 
 @pytest.fixture(autouse=True)
@@ -93,8 +96,8 @@ def test_querychat_client_has_system_prompt(sample_df):
     assert "test_table" in qc.system_prompt
 
 
-def test_generate_greeting_uses_querychat_system_prompt(sample_df):
-    """generate_greeting() should use the dataset-aware querychat system prompt."""
+def test_generate_greeting_uses_greeting_system_prompt(sample_df):
+    """generate_greeting() should use the lean greeting prompt, not the main query prompt."""
     qc = QueryChat(
         data_source=sample_df,
         table_name="test_table",
@@ -112,6 +115,7 @@ def test_generate_greeting_uses_querychat_system_prompt(sample_df):
     assert greeting == "Hello from querychat"
     assert seen["system_prompt"] is not None
     assert "test_table" in seen["system_prompt"]
+    assert "data dashboard chatbot" not in seen["system_prompt"]
 
 
 def test_generate_greeting_does_not_register_querychat_tools(sample_df):
@@ -152,7 +156,9 @@ def test_querychat_with_polars_lazyframe():
     assert isinstance(qc._data_sources["test_table"], PolarsLazySource)
 
     # Query should return a native polars LazyFrame
-    result = qc._data_sources["test_table"].execute_query("SELECT * FROM test_table WHERE id = 2")
+    result = qc._data_sources["test_table"].execute_query(
+        "SELECT * FROM test_table WHERE id = 2"
+    )
     assert isinstance(result, pl.LazyFrame)
 
     # Collect to verify
@@ -185,7 +191,9 @@ def test_querychat_with_ibis_table():
         assert isinstance(qc._data_sources["test_table"], IbisSource)
 
         # Query should return an ibis.Table
-        result = qc._data_sources["test_table"].execute_query("SELECT * FROM test_table WHERE id = 2")
+        result = qc._data_sources["test_table"].execute_query(
+            "SELECT * FROM test_table WHERE id = 2"
+        )
         assert isinstance(result, ibis.Table)
 
         # Execute to verify results
@@ -194,3 +202,108 @@ def test_querychat_with_ibis_table():
         assert executed["name"].iloc[0] == "Bob"
     finally:
         conn.disconnect()
+
+
+@pytest.fixture
+def sqlite_engine():
+    """SQLite engine with two tables for add_tables greeting tests."""
+    temp_db = tempfile.NamedTemporaryFile(delete=False, suffix=".db")  # noqa: SIM115
+    temp_db.close()
+    engine = create_engine(f"sqlite:///{temp_db.name}")
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE orders (id INTEGER, amount REAL)"))
+        conn.execute(text("CREATE TABLE customers (id INTEGER, name TEXT)"))
+        conn.execute(text("INSERT INTO orders VALUES (1, 100.0), (2, 200.0)"))
+        conn.execute(text("INSERT INTO customers VALUES (1, 'Alice'), (2, 'Bob')"))
+    yield engine
+    engine.dispose()
+    Path(temp_db.name).unlink()
+
+
+def test_greeter_tables_contains_constructor_table(sample_df):
+    """Constructor table is always present in greeter.tables."""
+    qc = QueryChat(data_source=sample_df, table_name="test_table")
+    assert "test_table" in qc.greeter.tables
+
+
+def test_constructor_greeting_survives_greeter_mutations(sample_df):
+    """Setting greeter.tables or greeter.prompt must not clear qc.greeting."""
+    qc = QueryChat(data_source=sample_df, table_name="test_table", greeting="Hello!")
+    assert qc.greeting == "Hello!"
+
+    qc.greeter.tables = ["test_table"]
+    assert qc.greeting == "Hello!"
+
+    qc.greeter.prompt = "Custom prompt"
+    assert qc.greeting == "Hello!"
+
+
+def test_add_table_include_in_greeting(sample_df):
+    """add_table with include_in_greeting=True adds the name; default False does not."""
+    qc = QueryChat()
+    qc.add_table(sample_df, "base_table", include_in_greeting=False)
+
+    extra = pd.DataFrame({"x": [1, 2]})
+    qc.add_table(extra, "included", include_in_greeting=True)
+
+    extra2 = pd.DataFrame({"y": [3, 4]})
+    qc.add_table(extra2, "excluded")
+
+    assert "included" in qc.greeter.tables
+    assert "excluded" not in qc.greeter.tables
+    assert "base_table" not in qc.greeter.tables
+
+
+def test_add_tables_include_in_greeting_true(sqlite_engine):
+    """add_tables with include_in_greeting=True adds all tables to greeter."""
+    qc = QueryChat()
+    qc.add_tables(sqlite_engine, include_in_greeting=True)
+    assert "orders" in qc.greeter.tables
+    assert "customers" in qc.greeter.tables
+
+
+def test_add_tables_include_in_greeting_false(sqlite_engine):
+    """add_tables with include_in_greeting=False (default) adds no tables to greeter."""
+    qc = QueryChat()
+    qc.add_tables(sqlite_engine, include_in_greeting=False)
+    assert "orders" not in qc.greeter.tables
+    assert "customers" not in qc.greeter.tables
+
+
+def test_add_tables_include_in_greeting_list(sqlite_engine):
+    """add_tables with a list only adds the named subset to greeter.tables."""
+    qc = QueryChat()
+    qc.add_tables(sqlite_engine, include_in_greeting=["orders"])
+    assert "orders" in qc.greeter.tables
+    assert "customers" not in qc.greeter.tables
+
+
+def test_generate_greeting_sets_greeting_and_returns_text(sample_df):
+    """generate_greeting() returns the mocked text and sets qc.greeting."""
+    qc = QueryChat(data_source=sample_df, table_name="test_table")
+    seen: dict[str, str | None] = {}
+
+    def fake_chat(self, *args, **kwargs):
+        seen["system_prompt"] = self.system_prompt
+        return "Generated greeting"
+
+    with patch("chatlas.Chat.chat", fake_chat):
+        result = qc.generate_greeting()
+
+    assert result == "Generated greeting"
+    assert qc.greeting == "Generated greeting"
+    assert seen["system_prompt"] is not None
+    assert "test_table" in seen["system_prompt"]
+    assert "data dashboard chatbot" not in seen["system_prompt"]
+
+
+def test_generate_greeting_with_empty_tables(sample_df):
+    """Clearing greeter.tables produces a generic greeting without raising."""
+    qc = QueryChat(data_source=sample_df, table_name="test_table")
+    qc.greeter.tables = []
+
+    with patch("chatlas.Chat.chat", return_value="Generic greeting"):
+        result = qc.generate_greeting()
+
+    assert result == "Generic greeting"
+    assert qc.greeting == "Generic greeting"

--- a/pkg-py/tests/test_querychat.py
+++ b/pkg-py/tests/test_querychat.py
@@ -300,6 +300,28 @@ def test_add_tables_include_in_greeting_invalid_type(sqlite_engine):
         qc.add_tables(sqlite_engine, include_in_greeting=1)  # type: ignore[arg-type]
 
 
+def test_greeting_prompt_omits_dicts_for_excluded_tables(sqlite_engine, tmp_path):
+    """A dict describing only excluded tables is dropped from the greeting prompt."""
+    orders_yaml = tmp_path / "orders.yaml"
+    orders_yaml.write_text(
+        "name: orders_dict\ndescription: ORDERS_DICT_DESC\n"
+        "tables:\n  orders:\n    description: Orders info\n"
+    )
+    customers_yaml = tmp_path / "customers.yaml"
+    customers_yaml.write_text(
+        "name: customers_dict\ndescription: CUSTOMERS_DICT_DESC\n"
+        "tables:\n  customers:\n    description: Customers info\n"
+    )
+
+    qc = QueryChat(data_dict=[str(orders_yaml), str(customers_yaml)])
+    qc.add_tables(sqlite_engine, include_in_greeting="orders")
+
+    prompt = qc._build_greeting_client().system_prompt
+    assert prompt is not None
+    assert "ORDERS_DICT_DESC" in prompt
+    assert "CUSTOMERS_DICT_DESC" not in prompt
+
+
 def test_generate_greeting_sets_greeting_and_returns_text(sample_df):
     """generate_greeting() returns the mocked text and sets qc.greeting."""
     qc = QueryChat(data_source=sample_df, table_name="test_table")

--- a/pkg-py/tests/test_shiny_module.py
+++ b/pkg-py/tests/test_shiny_module.py
@@ -46,5 +46,3 @@ def test_mod_ui_allow_attachments_can_be_overridden():
     with patch("querychat._shiny_module.shinychat.chat_ui", side_effect=_fake_chat_ui):
         mod_ui("test", allow_attachments=False)
         assert _fake_chat_ui.last_kwargs.get("allow_attachments") is False
-
-

--- a/pkg-py/tests/test_snowflake_source.py
+++ b/pkg-py/tests/test_snowflake_source.py
@@ -42,7 +42,9 @@ class TestFormatSemanticViewDdls:
 
     def test_format_single_view(self):
         """Test that format produces expected markdown structure for single view."""
-        views = [SemanticViewInfo(name="db.schema.view1", ddl="CREATE SEMANTIC VIEW v1")]
+        views = [
+            SemanticViewInfo(name="db.schema.view1", ddl="CREATE SEMANTIC VIEW v1")
+        ]
         section = format_semantic_view_ddls(views)
 
         assert "db.schema.view1" in section
@@ -134,7 +136,9 @@ class TestExecuteRawSQL:
         mock_cursor.fetchall.return_value = [("a", "b"), ("c", "d")]
 
         # raw_sql returns a context manager
-        mock_backend.raw_sql.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_backend.raw_sql.return_value.__enter__ = MagicMock(
+            return_value=mock_cursor
+        )
         mock_backend.raw_sql.return_value.__exit__ = MagicMock(return_value=False)
 
         result = execute_raw_sql("SELECT 1", mock_backend)

--- a/pkg-py/tests/test_state.py
+++ b/pkg-py/tests/test_state.py
@@ -556,6 +556,23 @@ class TestGetDisplayMessages:
         assert messages[0] == {"role": "user", "content": "Question"}
         assert messages[1] == {"role": "assistant", "content": "Answer"}
 
+    def test_legacy_greeting_prompt_turn_is_hidden(self, data_source, mock_client):
+        """
+        State serialized by older releases injected GREETING_PROMPT as a user
+        turn on the shared client; it must stay hidden after restore.
+        """
+        from chatlas import Turn
+        from querychat._querychat_core import GREETING_PROMPT
+
+        turns = [
+            Turn(role="user", contents=GREETING_PROMPT),
+            Turn(role="assistant", contents="Welcome!"),
+        ]
+        mock_client.get_turns.return_value = turns
+        state = AppState(data_sources={"test_table": data_source}, client=mock_client)
+        messages = state.get_display_messages()
+        assert messages == [{"role": "assistant", "content": "Welcome!"}]
+
 
 class TestTypedDicts:
     def test_app_state_dict_structure(self):

--- a/pkg-py/tests/test_state.py
+++ b/pkg-py/tests/test_state.py
@@ -62,7 +62,9 @@ class TestAppState:
 
     def test_with_greeting(self, data_source, mock_client):
         state = AppState(
-            data_sources={"test_table": data_source}, client=mock_client, greeting="Welcome!"
+            data_sources={"test_table": data_source},
+            client=mock_client,
+            greeting="Welcome!",
         )
         assert state.greeting == "Welcome!"
 
@@ -259,14 +261,25 @@ class TestAppState:
         )
 
         state.update_dashboard(
-            {"table": "orders", "query": "SELECT * FROM orders WHERE amount > 100", "title": "Big orders"}
+            {
+                "table": "orders",
+                "query": "SELECT * FROM orders WHERE amount > 100",
+                "title": "Big orders",
+            }
         )
         state.update_dashboard(
-            {"table": "customers", "query": "SELECT * FROM customers WHERE state = 'CA'", "title": "CA customers"}
+            {
+                "table": "customers",
+                "query": "SELECT * FROM customers WHERE state = 'CA'",
+                "title": "CA customers",
+            }
         )
 
         # orders' filter should still be intact
-        assert state._table_states["orders"]["sql"] == "SELECT * FROM orders WHERE amount > 100"
+        assert (
+            state._table_states["orders"]["sql"]
+            == "SELECT * FROM orders WHERE amount > 100"
+        )
         assert state._table_states["orders"]["title"] == "Big orders"
         # customers is now active
         assert state.active_table == "customers"
@@ -286,17 +299,31 @@ class TestAppState:
             query_executor=qc._require_query_executor("test"),
         )
         state.update_dashboard(
-            {"table": "orders", "query": "SELECT * FROM orders WHERE amount > 100", "title": "Big orders"}
+            {
+                "table": "orders",
+                "query": "SELECT * FROM orders WHERE amount > 100",
+                "title": "Big orders",
+            }
         )
         state.update_dashboard(
-            {"table": "customers", "query": "SELECT * FROM customers WHERE state = 'CA'", "title": "CA customers"}
+            {
+                "table": "customers",
+                "query": "SELECT * FROM customers WHERE state = 'CA'",
+                "title": "CA customers",
+            }
         )
 
         result = state.to_dict()
 
         assert "table_states" in result
-        assert result["table_states"]["orders"]["sql"] == "SELECT * FROM orders WHERE amount > 100"
-        assert result["table_states"]["customers"]["sql"] == "SELECT * FROM customers WHERE state = 'CA'"
+        assert (
+            result["table_states"]["orders"]["sql"]
+            == "SELECT * FROM orders WHERE amount > 100"
+        )
+        assert (
+            result["table_states"]["customers"]["sql"]
+            == "SELECT * FROM customers WHERE state = 'CA'"
+        )
 
     def test_update_from_dict_restores_per_table_states(self, mock_client):
         """update_from_dict() should restore all tables' sql/title/error."""
@@ -318,8 +345,16 @@ class TestAppState:
                 "title": "CA customers",
                 "error": None,
                 "table_states": {
-                    "orders": {"sql": "SELECT * FROM orders WHERE amount > 100", "title": "Big orders", "error": None},
-                    "customers": {"sql": "SELECT * FROM customers WHERE state = 'CA'", "title": "CA customers", "error": None},
+                    "orders": {
+                        "sql": "SELECT * FROM orders WHERE amount > 100",
+                        "title": "Big orders",
+                        "error": None,
+                    },
+                    "customers": {
+                        "sql": "SELECT * FROM customers WHERE state = 'CA'",
+                        "title": "CA customers",
+                        "error": None,
+                    },
                 },
                 "turns": [],
             }
@@ -327,7 +362,10 @@ class TestAppState:
 
         assert state.active_table == "customers"
         assert state.sql == "SELECT * FROM customers WHERE state = 'CA'"
-        assert state._table_states["orders"]["sql"] == "SELECT * FROM orders WHERE amount > 100"
+        assert (
+            state._table_states["orders"]["sql"]
+            == "SELECT * FROM orders WHERE amount > 100"
+        )
         assert state._table_states["orders"]["title"] == "Big orders"
 
 

--- a/pkg-py/tests/test_system_prompt.py
+++ b/pkg-py/tests/test_system_prompt.py
@@ -346,11 +346,7 @@ class TestVizPromptConditionals:
         to querychat_query should not appear in the rendered prompt.
         """
         template_path = (
-            Path(__file__).parent.parent
-            / "src"
-            / "querychat"
-            / "prompts"
-            / "prompt.md"
+            Path(__file__).parent.parent / "src" / "querychat" / "prompts" / "prompt.md"
         )
         prompt = QueryChatSystemPrompt(
             prompt_template=template_path,
@@ -361,19 +357,13 @@ class TestVizPromptConditionals:
 
         assert "fall back to" not in rendered
 
-    def test_collapsed_guidance_included_with_both_tools(
-        self, sample_data_source
-    ):
+    def test_collapsed_guidance_included_with_both_tools(self, sample_data_source):
         """
         When both query and visualize are enabled, the collapsed query
         guidance should appear in the system prompt.
         """
         template_path = (
-            Path(__file__).parent.parent
-            / "src"
-            / "querychat"
-            / "prompts"
-            / "prompt.md"
+            Path(__file__).parent.parent / "src" / "querychat" / "prompts" / "prompt.md"
         )
         prompt = QueryChatSystemPrompt(
             prompt_template=template_path,
@@ -391,11 +381,7 @@ class TestVizPromptConditionals:
         "Visualizing Data".
         """
         template_path = (
-            Path(__file__).parent.parent
-            / "src"
-            / "querychat"
-            / "prompts"
-            / "prompt.md"
+            Path(__file__).parent.parent / "src" / "querychat" / "prompts" / "prompt.md"
         )
         prompt = QueryChatSystemPrompt(
             prompt_template=template_path,
@@ -413,11 +399,7 @@ class TestVizPromptConditionals:
         when both query and visualize are enabled.
         """
         template_path = (
-            Path(__file__).parent.parent
-            / "src"
-            / "querychat"
-            / "prompts"
-            / "prompt.md"
+            Path(__file__).parent.parent / "src" / "querychat" / "prompts" / "prompt.md"
         )
         prompt = QueryChatSystemPrompt(
             prompt_template=template_path,

--- a/pkg-py/tests/test_truncate_error.py
+++ b/pkg-py/tests/test_truncate_error.py
@@ -21,7 +21,10 @@ class TestTruncateError:
         assert result == "Something went wrong\n\n(error truncated)"
 
     def test_truncates_at_schema_dump_line(self):
-        msg = "Bad property\nFailed validating 'additionalProperties' in schema[0]:\n" + "x" * 500
+        msg = (
+            "Bad property\nFailed validating 'additionalProperties' in schema[0]:\n"
+            + "x" * 500
+        )
         result = truncate_error(msg)
         assert "Bad property" in result
         assert "(error truncated)" in result
@@ -40,7 +43,10 @@ class TestTruncateError:
 
     def test_preserves_first_line_of_altair_error(self):
         first_line = "Additional properties are not allowed ('offset' was unexpected)"
-        schema_dump = "\n\nFailed validating 'additionalProperties' in schema[0]['properties']['encoding']:\n    {'additionalProperties': False,\n     'properties': {'angle': " + "x" * 10000
+        schema_dump = (
+            "\n\nFailed validating 'additionalProperties' in schema[0]['properties']['encoding']:\n    {'additionalProperties': False,\n     'properties': {'angle': "
+            + "x" * 10000
+        )
         msg = first_line + schema_dump
         result = truncate_error(msg)
         assert result.startswith(first_line)

--- a/pkg-py/tests/test_viz_footer.py
+++ b/pkg-py/tests/test_viz_footer.py
@@ -17,9 +17,7 @@ from querychat._datasource import DataFrameSource
 
 @pytest.fixture
 def sample_df():
-    return pl.DataFrame(
-        {"x": [1, 2, 3, 4, 5], "y": [10, 20, 15, 25, 30]}
-    )
+    return pl.DataFrame({"x": [1, 2, 3, 4, 5], "y": [10, 20, 15, 25, 30]})
 
 
 @pytest.fixture
@@ -34,9 +32,7 @@ def _mock_output_widget(widget_id, **kwargs):
 
 @pytest.fixture(autouse=True)
 def _patch_deps(monkeypatch):
-    monkeypatch.setattr(
-        "shinywidgets.register_widget", lambda _widget_id, _chart: None
-    )
+    monkeypatch.setattr("shinywidgets.register_widget", lambda _widget_id, _chart: None)
     monkeypatch.setattr("shinywidgets.output_widget", _mock_output_widget)
 
     mock_spec = MagicMock()
@@ -49,9 +45,7 @@ def _patch_deps(monkeypatch):
     mock_altair_widget.widget_id = "querychat_viz_test1234"
     mock_altair_widget.is_compound = False
 
-    monkeypatch.setattr(
-        "querychat._viz_ggsql.execute_ggsql", lambda _ds, _q: mock_spec
-    )
+    monkeypatch.setattr("querychat._viz_ggsql.execute_ggsql", lambda _ds, _q: mock_spec)
     monkeypatch.setattr(
         "querychat._viz_altair_widget.AltairWidget.from_ggsql",
         staticmethod(lambda _spec: mock_altair_widget),
@@ -99,7 +93,9 @@ class TestVizPreloadMarkup:
 
         rendered = TagList(preload_viz_deps_ui()).render()
         preload_dep = next(
-            dep for dep in rendered["dependencies"] if dep.name == "querychat-viz-preload"
+            dep
+            for dep in rendered["dependencies"]
+            if dep.name == "querychat-viz-preload"
         )
 
         assert PRELOAD_WIDGET_ID in rendered["html"]

--- a/pkg-r/DESCRIPTION
+++ b/pkg-r/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     rlang (>= 1.1.0),
     S7,
     shiny,
-    shinychat (> 0.4.0),
+    shinychat (>= 0.4.0),
     utils,
     whisker,
     yaml

--- a/pkg-r/NEWS.md
+++ b/pkg-r/NEWS.md
@@ -33,7 +33,7 @@
 
 ## Improvements
 
-* Chat greetings now use shinychat's greeting API (requires shinychat >= 0.4.0). A provided `greeting` renders instantly when the app loads, and when no `greeting` is given one is generated on demand without being added to the conversation history. Generated greetings are now preserved across bookmark/restore. (#249)
+* Chat greetings now use shinychat's greeting API (requires shinychat >= 0.4.0). A provided `greeting` renders instantly when the app loads, and when no `greeting` is given one is generated on demand — now **schema-aware**, so it can describe the data it's about to help you explore — without being added to the conversation history. Generated greetings are preserved across bookmark/restore. Tables passed to `QueryChat$new()` are described in the greeting automatically; opt additional tables in with `include_in_greeting = TRUE` on `$add_table()`/`$add_tables()`, or fine-tune which tables and which template the greeting uses via `qc$greeter`. (#249, #261)
 
 * The system prompt is now lighter: full schema is no longer embedded upfront. Instead the LLM fetches per-table schema on demand via the new `querychat_get_schema` tool — and only when it needs to. When a `data_dict` is provided, the tool skips columns that already have descriptions, so the LLM only pays for what isn't already documented. (#195)
 

--- a/pkg-r/R/QueryChat.R
+++ b/pkg-r/R/QueryChat.R
@@ -499,7 +499,7 @@ QueryChat <- R6::R6Class(
     #' @param include_in_greeting Whether to include added tables in the greeting
     #'   context. `TRUE` includes all tables; `FALSE` (default) includes none;
     #'   a character vector includes only those named tables (intersected with
-    #'   the tables being added).
+    #'   the tables being added). Any other type raises an error.
     #'
     #' @return Invisibly returns `self` for chaining.
     add_tables = function(
@@ -574,10 +574,16 @@ QueryChat <- R6::R6Class(
         private$.query_executor <- NULL
       }
 
+      if (
+        !rlang::is_bool(include_in_greeting) &&
+          !is.character(include_in_greeting)
+      ) {
+        cli::cli_abort(
+          "{.arg include_in_greeting} must be {.code TRUE}, {.code FALSE}, or a character vector of table names."
+        )
+      }
       greeting_tbls <- if (isTRUE(include_in_greeting)) {
         tables
-      } else if (identical(include_in_greeting, FALSE)) {
-        character()
       } else if (is.character(include_in_greeting)) {
         intersect(include_in_greeting, tables)
       } else {

--- a/pkg-r/R/QueryChat.R
+++ b/pkg-r/R/QueryChat.R
@@ -627,6 +627,12 @@ QueryChat <- R6::R6Class(
       ]
       private$build_system_prompt(data_sources = next_sources)
       private$.data_sources <- next_sources
+      if (!is.null(private$.greeter)) {
+        private$.greeter$tables <- setdiff(
+          private$.greeter$tables,
+          table_name
+        )
+      }
       if (!is.null(private$.query_executor)) {
         tryCatch(private$.query_executor$cleanup(), error = function(e) NULL)
         private$.query_executor <- NULL

--- a/pkg-r/R/QueryChat.R
+++ b/pkg-r/R/QueryChat.R
@@ -959,7 +959,12 @@ QueryChat <- R6::R6Class(
       if (!is.null(data_source)) {
         tbl_name <- private$.deferred_table_name %||%
           names(private$.data_sources)[[1]]
-        self$add_table(data_source, tbl_name, replace = TRUE)
+        self$add_table(
+          data_source,
+          tbl_name,
+          replace = TRUE,
+          include_in_greeting = TRUE
+        )
       }
 
       private$require_initialized("$server")

--- a/pkg-r/R/QueryChat.R
+++ b/pkg-r/R/QueryChat.R
@@ -539,6 +539,22 @@ QueryChat <- R6::R6Class(
         }
       }
 
+      if (
+        !rlang::is_bool(include_in_greeting) &&
+          !is.character(include_in_greeting)
+      ) {
+        cli::cli_abort(
+          "{.arg include_in_greeting} must be {.code TRUE}, {.code FALSE}, or a character vector of table names."
+        )
+      }
+      greeting_tbls <- if (isTRUE(include_in_greeting)) {
+        tables
+      } else if (is.character(include_in_greeting)) {
+        intersect(include_in_greeting, tables)
+      } else {
+        character()
+      }
+
       normalized <- stats::setNames(
         lapply(tables, function(tbl) normalize_data_source(conn, tbl)),
         tables
@@ -581,21 +597,6 @@ QueryChat <- R6::R6Class(
         private$.query_executor <- NULL
       }
 
-      if (
-        !rlang::is_bool(include_in_greeting) &&
-          !is.character(include_in_greeting)
-      ) {
-        cli::cli_abort(
-          "{.arg include_in_greeting} must be {.code TRUE}, {.code FALSE}, or a character vector of table names."
-        )
-      }
-      greeting_tbls <- if (isTRUE(include_in_greeting)) {
-        tables
-      } else if (is.character(include_in_greeting)) {
-        intersect(include_in_greeting, tables)
-      } else {
-        character()
-      }
       if (length(greeting_tbls) > 0) {
         self$greeter$tables <- c(self$greeter$tables, greeting_tbls)
       }

--- a/pkg-r/R/QueryChat.R
+++ b/pkg-r/R/QueryChat.R
@@ -109,12 +109,23 @@ QueryChat <- R6::R6Class(
       data_sources <- private$.data_sources
       tbls <- intersect(self$greeter$tables, names(data_sources))
       sources <- data_sources[tbls]
-      # Only keep dicts that describe an included table, so a curated greeting
-      # subset doesn't carry dict-level prose about excluded tables.
+      # Keep a dict if it describes an included table, or if it is a global
+      # (table-less) dict carrying a dict-level description. Drop the
+      # cross-table global fields (relationships, glossary) so a curated greeting
+      # subset can't leak excluded-table prose; per-table entries are scoped to
+      # the included tables at render time.
       greeting_dicts <- Filter(
-        function(dd) length(intersect(names(dd$tables), tbls)) > 0,
+        function(dd) {
+          length(intersect(names(dd$tables), tbls)) > 0 ||
+            (length(dd$tables) == 0 && !is.null(dd$description))
+        },
         private$.data_dicts
       )
+      greeting_dicts <- lapply(greeting_dicts, function(dd) {
+        dd$relationships <- NULL
+        dd$glossary <- NULL
+        dd
+      })
       greeting_prompt_obj <- QueryChatSystemPrompt$new(
         prompt_template = self$greeter$prompt,
         data_sources = sources,

--- a/pkg-r/R/QueryChat.R
+++ b/pkg-r/R/QueryChat.R
@@ -108,9 +108,6 @@ QueryChat <- R6::R6Class(
     build_greeting_client = function(client_spec = NULL) {
       data_sources <- private$.data_sources
       tbls <- intersect(self$greeter$tables, names(data_sources))
-      if (length(tbls) == 0) {
-        tbls <- names(data_sources)
-      }
       sources <- data_sources[tbls]
       greeting_prompt_obj <- QueryChatSystemPrompt$new(
         prompt_template = self$greeter$prompt,

--- a/pkg-r/R/QueryChat.R
+++ b/pkg-r/R/QueryChat.R
@@ -105,43 +105,6 @@ QueryChat <- R6::R6Class(
     .data_dicts = list(),
     .greeter = NULL,
 
-    build_greeting_client = function(client_spec = NULL) {
-      data_sources <- private$.data_sources
-      tbls <- intersect(self$greeter$tables, names(data_sources))
-      sources <- data_sources[tbls]
-      # Keep a dict if it describes an included table, or if it is a global
-      # (table-less) dict carrying a dict-level description. Drop the
-      # cross-table global fields (relationships, glossary) so a curated greeting
-      # subset can't leak excluded-table prose; per-table entries are scoped to
-      # the included tables at render time.
-      greeting_dicts <- Filter(
-        function(dd) {
-          length(intersect(names(dd$tables), tbls)) > 0 ||
-            (length(dd$tables) == 0 && !is.null(dd$description))
-        },
-        private$.data_dicts
-      )
-      greeting_dicts <- lapply(greeting_dicts, function(dd) {
-        dd$relationships <- NULL
-        dd$glossary <- NULL
-        dd
-      })
-      greeting_prompt_obj <- QueryChatSystemPrompt$new(
-        prompt_template = self$greeter$prompt,
-        data_sources = sources,
-        data_description = private$.data_description,
-        extra_instructions = NULL,
-        categorical_threshold = private$.categorical_threshold,
-        data_dicts = greeting_dicts
-      )
-      spec <- client_spec %||% private$.client_spec
-      chat <- as_querychat_client(spec)
-      chat <- chat$clone()
-      chat$set_turns(list())
-      chat$set_system_prompt(greeting_prompt_obj$render(tools = NULL))
-      chat
-    },
-
     require_initialized = function(method_name) {
       if (length(private$.data_sources) == 0) {
         cli::cli_abort(
@@ -974,16 +937,13 @@ QueryChat <- R6::R6Class(
       }
 
       resolved_client_spec <- client %||% private$.client_spec
+      base_client <- as_querychat_client(resolved_client_spec)
 
       create_session_client <- function(...) {
         private$create_session_client(
-          client_spec = resolved_client_spec,
+          client_spec = base_client,
           ...
         )
-      }
-
-      greeting_client_fn <- function() {
-        private$build_greeting_client(client_spec = resolved_client_spec)
       }
 
       result <- mod_server(
@@ -993,7 +953,8 @@ QueryChat <- R6::R6Class(
         greeting = self$greeting,
         client = create_session_client,
         tools = self$tools,
-        greeting_client_fn = greeting_client_fn,
+        greeter = self$greeter,
+        greeting_base = base_client,
         enable_bookmarking = enable_bookmarking
       )
       result
@@ -1007,7 +968,9 @@ QueryChat <- R6::R6Class(
     #' @return The greeting string in Markdown format.
     generate_greeting = function(echo = c("none", "output")) {
       private$require_initialized("$generate_greeting")
-      self$greeter$generate(echo = echo)
+      greeting <- self$greeter$generate(echo = echo)
+      self$greeting <- greeting
+      greeting
     },
 
     #' @description
@@ -1034,8 +997,27 @@ QueryChat <- R6::R6Class(
         # trigger a write-back of the (unchanged) binding, which we ignore.
         return(invisible(value))
       }
-      private$.greeter <- private$.greeter %||%
-        QueryChatGreeter$new(parent = self)
+      if (is.null(private$.greeter)) {
+        client_factory <- function(tables, prompt, base = NULL) {
+          sp <- QueryChatSystemPrompt$new(
+            prompt_template = prompt,
+            data_sources = private$.data_sources,
+            data_description = private$.data_description,
+            extra_instructions = NULL,
+            categorical_threshold = private$.categorical_threshold,
+            data_dicts = private$.data_dicts,
+            include_tables = tables,
+            include_relationships = FALSE,
+            include_glossary = FALSE
+          )
+          chat <- create_client(base %||% private$.client_spec)
+          chat$set_system_prompt(sp$render(tools = NULL))
+          chat
+        }
+        private$.greeter <- QueryChatGreeter$new(
+          client_factory = client_factory
+        )
+      }
       private$.greeter
     },
 

--- a/pkg-r/R/QueryChat.R
+++ b/pkg-r/R/QueryChat.R
@@ -109,13 +109,19 @@ QueryChat <- R6::R6Class(
       data_sources <- private$.data_sources
       tbls <- intersect(self$greeter$tables, names(data_sources))
       sources <- data_sources[tbls]
+      # Only keep dicts that describe an included table, so a curated greeting
+      # subset doesn't carry dict-level prose about excluded tables.
+      greeting_dicts <- Filter(
+        function(dd) length(intersect(names(dd$tables), tbls)) > 0,
+        private$.data_dicts
+      )
       greeting_prompt_obj <- QueryChatSystemPrompt$new(
         prompt_template = self$greeter$prompt,
         data_sources = sources,
         data_description = private$.data_description,
         extra_instructions = NULL,
         categorical_threshold = private$.categorical_threshold,
-        data_dicts = private$.data_dicts
+        data_dicts = greeting_dicts
       )
       spec <- client_spec %||% private$.client_spec
       chat <- as_querychat_client(spec)

--- a/pkg-r/R/QueryChat.R
+++ b/pkg-r/R/QueryChat.R
@@ -196,9 +196,7 @@ QueryChat <- R6::R6Class(
       visualize = function(data) {}
     ) {
       spec <- client_spec %||% private$.client_spec
-      chat <- as_querychat_client(spec)
-      chat <- chat$clone()
-      chat$set_turns(list())
+      chat <- create_client(spec)
 
       if (is_na(tools)) {
         tools <- self$tools

--- a/pkg-r/R/QueryChat.R
+++ b/pkg-r/R/QueryChat.R
@@ -432,6 +432,7 @@ QueryChat <- R6::R6Class(
       if (private$.server_initialized) {
         cli::cli_abort("Cannot add tables after server initialization.")
       }
+      check_bool(include_in_greeting)
       check_sql_table_name(table_name)
       if (table_name %in% names(private$.data_sources) && !replace) {
         cli::cli_abort(

--- a/pkg-r/R/QueryChat.R
+++ b/pkg-r/R/QueryChat.R
@@ -103,6 +103,30 @@ QueryChat <- R6::R6Class(
     .extra_instructions = NULL,
     .categorical_threshold = NULL,
     .data_dicts = list(),
+    .greeter = NULL,
+
+    build_greeting_client = function(client_spec = NULL) {
+      data_sources <- private$.data_sources
+      tbls <- intersect(self$greeter$tables, names(data_sources))
+      if (length(tbls) == 0) {
+        tbls <- names(data_sources)
+      }
+      sources <- data_sources[tbls]
+      greeting_prompt_obj <- QueryChatSystemPrompt$new(
+        prompt_template = self$greeter$prompt,
+        data_sources = sources,
+        data_description = private$.data_description,
+        extra_instructions = NULL,
+        categorical_threshold = private$.categorical_threshold,
+        data_dicts = private$.data_dicts
+      )
+      spec <- client_spec %||% private$.client_spec
+      chat <- as_querychat_client(spec)
+      chat <- chat$clone()
+      chat$set_turns(list())
+      chat$set_system_prompt(greeting_prompt_obj$render(tools = NULL))
+      chat
+    },
 
     require_initialized = function(method_name) {
       if (length(private$.data_sources) == 0) {
@@ -365,6 +389,7 @@ QueryChat <- R6::R6Class(
         private$.data_sources[[normalized$table_name]] <- normalized
         private$auto_fill_data_description()
         private$build_system_prompt()
+        self$greeter$tables <- c(self$greeter$tables, normalized$table_name)
         self$id <- id %||% sprintf("querychat_%s", normalized$table_name)
       } else {
         # Deferred pattern: data_source is NULL
@@ -397,9 +422,16 @@ QueryChat <- R6::R6Class(
     #' @param table_name The SQL table name for this data source.
     #' @param replace Whether to replace an existing table with this name.
     #'   Default is `FALSE`.
+    #' @param include_in_greeting Whether to include this table in the greeting
+    #'   context. Default is `FALSE`.
     #'
     #' @return Invisibly returns `self` for chaining.
-    add_table = function(data_source, table_name, replace = FALSE) {
+    add_table = function(
+      data_source,
+      table_name,
+      replace = FALSE,
+      include_in_greeting = FALSE
+    ) {
       if (private$.server_initialized) {
         cli::cli_abort("Cannot add tables after server initialization.")
       }
@@ -447,6 +479,10 @@ QueryChat <- R6::R6Class(
         self$id <- sprintf("querychat_%s", table_name)
       }
 
+      if (isTRUE(include_in_greeting)) {
+        self$greeter$tables <- c(self$greeter$tables, table_name)
+      }
+
       invisible(self)
     },
 
@@ -463,9 +499,18 @@ QueryChat <- R6::R6Class(
     #'   by `DBI::dbListTables(conn)` are used.
     #' @param replace Whether to replace existing tables with the same name.
     #'   Default is `FALSE`.
+    #' @param include_in_greeting Whether to include added tables in the greeting
+    #'   context. `TRUE` includes all tables; `FALSE` (default) includes none;
+    #'   a character vector includes only those named tables (intersected with
+    #'   the tables being added).
     #'
     #' @return Invisibly returns `self` for chaining.
-    add_tables = function(conn, tables = NULL, replace = FALSE) {
+    add_tables = function(
+      conn,
+      tables = NULL,
+      replace = FALSE,
+      include_in_greeting = FALSE
+    ) {
       if (private$.server_initialized) {
         cli::cli_abort("Cannot add tables after server initialization.")
       }
@@ -530,6 +575,19 @@ QueryChat <- R6::R6Class(
       if (!is.null(private$.query_executor)) {
         tryCatch(private$.query_executor$cleanup(), error = function(e) NULL)
         private$.query_executor <- NULL
+      }
+
+      greeting_tbls <- if (isTRUE(include_in_greeting)) {
+        tables
+      } else if (identical(include_in_greeting, FALSE)) {
+        character()
+      } else if (is.character(include_in_greeting)) {
+        intersect(include_in_greeting, tables)
+      } else {
+        character()
+      }
+      if (length(greeting_tbls) > 0) {
+        self$greeter$tables <- c(self$greeter$tables, greeting_tbls)
       }
 
       invisible(self)
@@ -893,6 +951,10 @@ QueryChat <- R6::R6Class(
         )
       }
 
+      greeting_client_fn <- function() {
+        private$build_greeting_client(client_spec = resolved_client_spec)
+      }
+
       result <- mod_server(
         id %||% self$id,
         data_sources = private$.data_sources,
@@ -900,6 +962,7 @@ QueryChat <- R6::R6Class(
         greeting = self$greeting,
         client = create_session_client,
         tools = self$tools,
+        greeting_client_fn = greeting_client_fn,
         enable_bookmarking = enable_bookmarking
       )
       result
@@ -913,8 +976,7 @@ QueryChat <- R6::R6Class(
     #' @return The greeting string in Markdown format.
     generate_greeting = function(echo = c("none", "output")) {
       private$require_initialized("$generate_greeting")
-      chat <- private$create_session_client()
-      as.character(chat$chat(GREETING_PROMPT, echo = echo))
+      self$greeter$generate(echo = echo)
     },
 
     #' @description
@@ -932,6 +994,20 @@ QueryChat <- R6::R6Class(
     }
   ),
   active = list(
+    #' @field greeter The QueryChatGreeter controlling greeting generation;
+    #'   access its `$tables` and `$prompt`.
+    greeter = function(value) {
+      if (!missing(value)) {
+        # The greeter is read-only. Sub-field assignments like
+        # `qc$greeter$tables <- x` mutate the greeter by reference and
+        # trigger a write-back of the (unchanged) binding, which we ignore.
+        return(invisible(value))
+      }
+      private$.greeter <- private$.greeter %||%
+        QueryChatGreeter$new(parent = self)
+      private$.greeter
+    },
+
     #' @field system_prompt Get the system prompt.
     system_prompt = function() {
       private$require_initialized("$system_prompt")

--- a/pkg-r/R/QueryChatGreeter.R
+++ b/pkg-r/R/QueryChatGreeter.R
@@ -53,7 +53,7 @@ QueryChatGreeter <- R6::R6Class(
       stream <- client$stream_async(GREETING_PROMPT)
       p <- shinychat::chat_set_greeting(
         chat_id,
-        shinychat::chat_greeting(stream, dismissible = FALSE)
+        shinychat::chat_greeting(stream, persistent = TRUE, dismissible = FALSE)
       )
       promises::then(p, function(value) {
         greeting_reactive(client$last_turn()@text)

--- a/pkg-r/R/QueryChatGreeter.R
+++ b/pkg-r/R/QueryChatGreeter.R
@@ -53,7 +53,7 @@ QueryChatGreeter <- R6::R6Class(
       stream <- client$stream_async(GREETING_PROMPT)
       p <- shinychat::chat_set_greeting(
         chat_id,
-        shinychat::chat_greeting(stream, persistent = TRUE, dismissible = FALSE)
+        chat_greeting_persistent(stream)
       )
       promises::then(p, function(value) {
         greeting_reactive(client$last_turn()@text)

--- a/pkg-r/R/QueryChatGreeter.R
+++ b/pkg-r/R/QueryChatGreeter.R
@@ -8,15 +8,14 @@
 QueryChatGreeter <- R6::R6Class(
   "QueryChatGreeter",
   private = list(
-    .parent = NULL,
+    .client_factory = NULL,
     .tables = NULL,
     .prompt = NULL
   ),
   public = list(
-    #' @description Create a new QueryChatGreeter.
-    #' @param parent The owning QueryChat instance.
-    initialize = function(parent) {
-      private$.parent <- parent
+    #' @param client_factory function(tables, prompt, base) returning a configured greeting client.
+    initialize = function(client_factory) {
+      private$.client_factory <- client_factory
       private$.tables <- character()
       private$.prompt <- system.file(
         "prompts",
@@ -25,29 +24,52 @@ QueryChatGreeter <- R6::R6Class(
       )
     },
 
-    #' @description Generate a greeting using the greeting system prompt.
-    #' @param echo Whether to echo the output (`"none"` or `"output"`).
-    #' @return The greeting string.
-    generate = function(echo = c("none", "output")) {
+    #' @description Build a fresh greeting client (no history) configured with the greeting system prompt.
+    #' @param base Optional resolved client to clone (resolve-once base from `$server()`).
+    build_client = function(base = NULL) {
+      private$.client_factory(private$.tables, private$.prompt, base)
+    },
+
+    #' @description Generate a greeting synchronously and return it as text.
+    #' @param echo "none" or "output".
+    #' @param base Optional resolved client to clone.
+    generate = function(echo = c("none", "output"), base = NULL) {
       echo <- rlang::arg_match(echo)
-      chat <- private$.parent$.__enclos_env__$private$build_greeting_client()
-      txt <- as.character(chat$chat(GREETING_PROMPT, echo = echo))
-      private$.parent$greeting <- txt
-      txt
+      client <- self$build_client(base)
+      as.character(client$chat(GREETING_PROMPT, echo = echo))
+    },
+
+    #' @description Stream a greeting into the chat UI and capture the result
+    #'   (Shiny path).
+    #' @param greeting_reactive Session reactiveVal to receive the generated greeting.
+    #' @param base Optional resolved client to clone.
+    #' @param chat_id Chat component id targeted by the Shiny stream (default "chat").
+    generate_stream = function(
+      greeting_reactive,
+      base = NULL,
+      chat_id = "chat"
+    ) {
+      client <- self$build_client(base)
+      stream <- client$stream_async(GREETING_PROMPT)
+      p <- shinychat::chat_set_greeting(
+        chat_id,
+        shinychat::chat_greeting(stream, dismissible = FALSE)
+      )
+      promises::then(p, function(value) {
+        greeting_reactive(client$last_turn()@text)
+      })
+      p
     }
   ),
   active = list(
-    #' @field tables Character vector of table names whose context to include in
-    #'   the greeting. Changes affect the next generated greeting.
+    #' @field tables Character vector of table names whose context to include in the greeting.
     tables = function(value) {
       if (missing(value)) {
         return(private$.tables)
       }
-      private$.tables <- value
+      private$.tables <- value %||% character()
     },
-
-    #' @field prompt The greeting template (string or file path). Changes affect
-    #'   the next generated greeting.
+    #' @field prompt The greeting template (string or file path).
     prompt = function(value) {
       if (missing(value)) {
         return(private$.prompt)

--- a/pkg-r/R/QueryChatGreeter.R
+++ b/pkg-r/R/QueryChatGreeter.R
@@ -38,23 +38,21 @@ QueryChatGreeter <- R6::R6Class(
   ),
   active = list(
     #' @field tables Character vector of table names whose context to include in
-    #'   the greeting. Set to invalidate the cached greeting.
+    #'   the greeting. Changes affect the next generated greeting.
     tables = function(value) {
       if (missing(value)) {
         return(private$.tables)
       }
       private$.tables <- value
-      private$.parent$greeting <- NULL
     },
 
-    #' @field prompt The greeting template (string or file path). Set to
-    #'   invalidate the cached greeting.
+    #' @field prompt The greeting template (string or file path). Changes affect
+    #'   the next generated greeting.
     prompt = function(value) {
       if (missing(value)) {
         return(private$.prompt)
       }
       private$.prompt <- value
-      private$.parent$greeting <- NULL
     }
   )
 )

--- a/pkg-r/R/QueryChatGreeter.R
+++ b/pkg-r/R/QueryChatGreeter.R
@@ -1,0 +1,60 @@
+#' QueryChatGreeter
+#'
+#' @description
+#' Controls greeting generation for a [QueryChat] instance. Access via
+#' `qc$greeter`.
+#'
+#' @noRd
+QueryChatGreeter <- R6::R6Class(
+  "QueryChatGreeter",
+  private = list(
+    .parent = NULL,
+    .tables = NULL,
+    .prompt = NULL
+  ),
+  public = list(
+    #' @description Create a new QueryChatGreeter.
+    #' @param parent The owning QueryChat instance.
+    initialize = function(parent) {
+      private$.parent <- parent
+      private$.tables <- character()
+      private$.prompt <- system.file(
+        "prompts",
+        "greeting.md",
+        package = "querychat"
+      )
+    },
+
+    #' @description Generate a greeting using the greeting system prompt.
+    #' @param echo Whether to echo the output (`"none"` or `"output"`).
+    #' @return The greeting string.
+    generate = function(echo = c("none", "output")) {
+      echo <- rlang::arg_match(echo)
+      chat <- private$.parent$.__enclos_env__$private$build_greeting_client()
+      txt <- as.character(chat$chat(GREETING_PROMPT, echo = echo))
+      private$.parent$greeting <- txt
+      txt
+    }
+  ),
+  active = list(
+    #' @field tables Character vector of table names whose context to include in
+    #'   the greeting. Set to invalidate the cached greeting.
+    tables = function(value) {
+      if (missing(value)) {
+        return(private$.tables)
+      }
+      private$.tables <- value
+      private$.parent$greeting <- NULL
+    },
+
+    #' @field prompt The greeting template (string or file path). Set to
+    #'   invalidate the cached greeting.
+    prompt = function(value) {
+      if (missing(value)) {
+        return(private$.prompt)
+      }
+      private$.prompt <- value
+      private$.parent$greeting <- NULL
+    }
+  )
+)

--- a/pkg-r/R/QueryChatSystemPrompt.R
+++ b/pkg-r/R/QueryChatSystemPrompt.R
@@ -83,18 +83,20 @@ QueryChatSystemPrompt <- R6::R6Class(
     #'
     #' @return A character string containing the rendered system prompt.
     render = function(tools) {
-      first_source <- self$data_sources[[1]]
-      db_type <- first_source$get_db_type()
-      has_dicts <- length(self$data_dicts) > 0
+      # data_sources may be empty for a greeting with no included tables.
+      has_sources <- length(self$data_sources) > 0
+      first_source <- if (has_sources) self$data_sources[[1]] else NULL
+      db_type <- if (has_sources) first_source$get_db_type() else "SQL"
+      has_dicts <- has_sources && length(self$data_dicts) > 0
 
       semantic_views <- ""
-      if (inherits(first_source, "DBISource")) {
+      if (has_sources && inherits(first_source, "DBISource")) {
         semantic_views <- first_source$get_semantic_views_description()
       }
 
       # Compute schema for backward compat with templates using {{schema}}
       schema <- ""
-      if (grepl("\\{\\{[{#^/]?\\s*schema\\b", self$template)) {
+      if (has_sources && grepl("\\{\\{[{#^/]?\\s*schema\\b", self$template)) {
         schema <- first_source$get_schema(
           categorical_threshold = self$categorical_threshold
         )

--- a/pkg-r/R/QueryChatSystemPrompt.R
+++ b/pkg-r/R/QueryChatSystemPrompt.R
@@ -41,6 +41,12 @@ QueryChatSystemPrompt <- R6::R6Class(
     #' @param extra_instructions Optional path to instructions file or instructions string.
     #' @param categorical_threshold Threshold for categorical column detection (default: 10).
     #' @param data_dicts Optional list of data dict lists (from [read_data_dict()]).
+    #' @param include_tables `TRUE` (all tables), `FALSE` (none), or a character
+    #'   vector of table names to include.
+    #' @param include_relationships Logical; whether to retain relationship entries
+    #'   from data dicts (default `TRUE`).
+    #' @param include_glossary Logical; whether to retain glossary entries from
+    #'   data dicts (default `TRUE`).
     #'
     #' @return A new `QueryChatSystemPrompt` object.
     initialize = function(
@@ -49,7 +55,10 @@ QueryChatSystemPrompt <- R6::R6Class(
       data_description = NULL,
       extra_instructions = NULL,
       categorical_threshold = 10,
-      data_dicts = NULL
+      data_dicts = NULL,
+      include_tables = TRUE,
+      include_relationships = TRUE,
+      include_glossary = TRUE
     ) {
       self$template <- read_text(prompt_template)
 
@@ -65,7 +74,40 @@ QueryChatSystemPrompt <- R6::R6Class(
       self$data_sources <- data_sources
       self$data_dicts <- data_dicts %||% list()
 
-      if (length(data_sources) > 1 && length(self$data_dicts) == 0) {
+      if (!isTRUE(include_tables)) {
+        resolved <- if (isFALSE(include_tables)) {
+          character()
+        } else {
+          intersect(include_tables, names(data_sources))
+        }
+        self$data_sources <- data_sources[resolved]
+        # Keep a dict if it describes an included table, or if it is a global
+        # (table-less) dict carrying a dict-level description.
+        self$data_dicts <- Filter(
+          function(dd) {
+            length(intersect(names(dd$tables), resolved)) > 0 ||
+              (length(dd$tables) == 0 && !is.null(dd$description))
+          },
+          self$data_dicts
+        )
+        if (!include_relationships || !include_glossary) {
+          self$data_dicts <- lapply(self$data_dicts, function(dd) {
+            if (!include_relationships) {
+              dd$relationships <- NULL
+            }
+            if (!include_glossary) {
+              dd$glossary <- NULL
+            }
+            dd
+          })
+        }
+      }
+
+      if (
+        isTRUE(include_tables) &&
+          length(self$data_sources) > 1 &&
+          length(self$data_dicts) == 0
+      ) {
         cli::cli_warn(
           c(
             "Multiple tables registered without a {.arg data_dict}.",

--- a/pkg-r/R/QueryChatSystemPrompt.R
+++ b/pkg-r/R/QueryChatSystemPrompt.R
@@ -105,6 +105,7 @@ QueryChatSystemPrompt <- R6::R6Class(
       context <- list(
         db_type = db_type,
         is_duck_db = tolower(db_type) == "duckdb",
+        has_tables = has_sources,
         semantic_views = semantic_views,
         schema = schema,
         has_data_dicts = has_dicts,

--- a/pkg-r/R/QueryChatSystemPrompt.R
+++ b/pkg-r/R/QueryChatSystemPrompt.R
@@ -87,7 +87,9 @@ QueryChatSystemPrompt <- R6::R6Class(
       has_sources <- length(self$data_sources) > 0
       first_source <- if (has_sources) self$data_sources[[1]] else NULL
       db_type <- if (has_sources) first_source$get_db_type() else "SQL"
-      has_dicts <- has_sources && length(self$data_dicts) > 0
+      # Data dicts can carry global (table-less) descriptions, so they may
+      # render even when no tables are selected (e.g. a generic greeting).
+      has_dicts <- length(self$data_dicts) > 0
 
       semantic_views <- ""
       if (has_sources && inherits(first_source, "DBISource")) {

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -43,6 +43,7 @@ mod_server <- function(
   greeting,
   client,
   tools,
+  greeting_client_fn = NULL,
   enable_bookmarking = FALSE
 ) {
   shiny::moduleServer(id, function(input, output, session) {
@@ -155,7 +156,11 @@ mod_server <- function(
             "i" = "For faster startup, lower cost, and determinism, consider providing a {.arg greeting} to {.fn QueryChat}.",
             "i" = "You can use your {.help querychat::QueryChat} object's {.fn $generate_greeting} method to generate a greeting."
           ))
-          greeting_client <- client(tools = NULL)
+          greeting_client <- if (!is.null(greeting_client_fn)) {
+            greeting_client_fn()
+          } else {
+            client(tools = NULL)
+          }
           stream <- greeting_client$stream_async(GREETING_PROMPT)
           p <- shinychat::chat_set_greeting(
             "chat",

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -43,7 +43,8 @@ mod_server <- function(
   greeting,
   client,
   tools,
-  greeting_client_fn = NULL,
+  greeter = NULL,
+  greeting_base = NULL,
   enable_bookmarking = FALSE
 ) {
   shiny::moduleServer(id, function(input, output, session) {
@@ -156,20 +157,10 @@ mod_server <- function(
             "i" = "For faster startup, lower cost, and determinism, consider providing a {.arg greeting} to {.fn QueryChat}.",
             "i" = "You can use your {.help querychat::QueryChat} object's {.fn $generate_greeting} method to generate a greeting."
           ))
-          greeting_client <- if (!is.null(greeting_client_fn)) {
-            greeting_client_fn()
-          } else {
-            client(tools = NULL)
-          }
-          stream <- greeting_client$stream_async(GREETING_PROMPT)
-          p <- shinychat::chat_set_greeting(
-            "chat",
-            shinychat::chat_greeting(stream, dismissible = FALSE)
+          greeter$generate_stream(
+            greeting_reactive = current_greeting,
+            base = greeting_base
           )
-          # Capture the generated greeting so it can be bookmarked and restored.
-          promises::then(p, function(value) {
-            current_greeting(greeting_client$last_turn()@text)
-          })
         }
       )
     }

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -9,11 +9,7 @@ mod_ui <- function(
   ns <- shiny::NS(id)
 
   if (!is.null(greeting) && any(nzchar(greeting))) {
-    greeting <- shinychat::chat_greeting(
-      greeting,
-      persistent = TRUE,
-      dismissible = FALSE
-    )
+    greeting <- chat_greeting_persistent(greeting)
   } else {
     greeting <- NULL
   }
@@ -152,11 +148,7 @@ mod_server <- function(
           if (!is.null(current_greeting())) {
             shinychat::chat_set_greeting(
               "chat",
-              shinychat::chat_greeting(
-                current_greeting(),
-                persistent = TRUE,
-                dismissible = FALSE
-              )
+              chat_greeting_persistent(current_greeting())
             )
             return()
           }
@@ -261,11 +253,7 @@ mod_server <- function(
           current_greeting(state$values$querychat_greeting)
           shinychat::chat_set_greeting(
             "chat",
-            shinychat::chat_greeting(
-              state$values$querychat_greeting,
-              persistent = TRUE,
-              dismissible = FALSE
-            ),
+            chat_greeting_persistent(state$values$querychat_greeting),
             session = session
           )
         }

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -9,7 +9,11 @@ mod_ui <- function(
   ns <- shiny::NS(id)
 
   if (!is.null(greeting) && any(nzchar(greeting))) {
-    greeting <- shinychat::chat_greeting(greeting, persistent = TRUE, dismissible = FALSE)
+    greeting <- shinychat::chat_greeting(
+      greeting,
+      persistent = TRUE,
+      dismissible = FALSE
+    )
   } else {
     greeting <- NULL
   }
@@ -148,7 +152,11 @@ mod_server <- function(
           if (!is.null(current_greeting())) {
             shinychat::chat_set_greeting(
               "chat",
-              shinychat::chat_greeting(current_greeting(), persistent = TRUE, dismissible = FALSE)
+              shinychat::chat_greeting(
+                current_greeting(),
+                persistent = TRUE,
+                dismissible = FALSE
+              )
             )
             return()
           }

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -9,7 +9,7 @@ mod_ui <- function(
   ns <- shiny::NS(id)
 
   if (!is.null(greeting) && any(nzchar(greeting))) {
-    greeting <- shinychat::chat_greeting(greeting, dismissible = FALSE)
+    greeting <- shinychat::chat_greeting(greeting, persistent = TRUE, dismissible = FALSE)
   } else {
     greeting <- NULL
   }
@@ -148,7 +148,7 @@ mod_server <- function(
           if (!is.null(current_greeting())) {
             shinychat::chat_set_greeting(
               "chat",
-              shinychat::chat_greeting(current_greeting(), dismissible = FALSE)
+              shinychat::chat_greeting(current_greeting(), persistent = TRUE, dismissible = FALSE)
             )
             return()
           }
@@ -255,6 +255,7 @@ mod_server <- function(
             "chat",
             shinychat::chat_greeting(
               state$values$querychat_greeting,
+              persistent = TRUE,
               dismissible = FALSE
             ),
             session = session

--- a/pkg-r/R/utils-ellmer.R
+++ b/pkg-r/R/utils-ellmer.R
@@ -43,6 +43,12 @@ as_querychat_client <- function(client = NULL) {
   client
 }
 
+create_client <- function(client = NULL) {
+  chat <- as_querychat_client(client)$clone()
+  chat$set_turns(list())
+  chat
+}
+
 querychat_client_option <- function() {
   opt <- getOption("querychat.client", NULL)
   if (!is.null(opt)) {

--- a/pkg-r/R/utils-shinychat.R
+++ b/pkg-r/R/utils-shinychat.R
@@ -1,0 +1,9 @@
+# shinychat compatibility helpers
+
+chat_greeting_persistent <- function(content) {
+  if (utils::packageVersion("shinychat") > "0.4.0") {
+    shinychat::chat_greeting(content, persistent = TRUE)
+  } else {
+    shinychat::chat_greeting(content, dismissible = FALSE)
+  }
+}

--- a/pkg-r/R/utils-shinychat.R
+++ b/pkg-r/R/utils-shinychat.R
@@ -1,5 +1,6 @@
 # shinychat compatibility helpers
 
+# TODO: remove once shinychat >= 0.5.0 is the minimum (persistent added in 0.4.0.9000)
 chat_greeting_persistent <- function(content) {
   if (utils::packageVersion("shinychat") > "0.4.0") {
     shinychat::chat_greeting(content, persistent = TRUE)

--- a/pkg-r/inst/prompts/greeting.md
+++ b/pkg-r/inst/prompts/greeting.md
@@ -3,21 +3,23 @@ You are a friendly data assistant. Write a warm welcome greeting for a user who 
 {{#has_tables}}
 You have access to a {{db_type}} database with the following tables:
 
-{{#has_data_dicts}}
-{{{data_dicts}}}
-
-{{/has_data_dicts}}
-{{^has_data_dicts}}
-<tables>
-{{{tables_overview}}}
-</tables>
-
-{{/has_data_dicts}}
 {{/has_tables}}
 {{^has_tables}}
 You have access to a {{db_type}} database.
 
 {{/has_tables}}
+{{#has_data_dicts}}
+{{{data_dicts}}}
+
+{{/has_data_dicts}}
+{{^has_data_dicts}}
+{{#has_tables}}
+<tables>
+{{{tables_overview}}}
+</tables>
+
+{{/has_tables}}
+{{/has_data_dicts}}
 {{#data_description}}
 <data_description>
 {{{data_description}}}

--- a/pkg-r/inst/prompts/greeting.md
+++ b/pkg-r/inst/prompts/greeting.md
@@ -1,0 +1,62 @@
+You are a friendly data assistant. Write a warm welcome greeting for a user who is about to explore their data.
+
+You have access to a {{db_type}} SQL database with the following tables:
+
+{{#has_data_dicts}}
+{{{data_dicts}}}
+
+{{/has_data_dicts}}
+{{^has_data_dicts}}
+<tables>
+{{{tables_overview}}}
+</tables>
+
+{{/has_data_dicts}}
+{{#data_description}}
+<data_description>
+{{{data_description}}}
+</data_description>
+
+{{/data_description}}
+Your greeting should be brief, warm, and focused on what the user can do with this data. Mention 2–4 concrete things the user might want to explore or ask about.
+
+### Providing Suggestions for Next Steps
+
+#### Suggestion Syntax
+
+Use `<span class="suggestion">` tags to create clickable suggestion buttons in the UI. The text inside should be a complete, actionable suggestion that users can click to continue the conversation.
+
+**List format (most common):**
+```
+<ul>
+<li><span class="suggestion">Show me examples of …</span></li>
+<li><span class="suggestion">What are the key differences between …</span></li>
+<li><span class="suggestion">Explain how …</span></li>
+</ul>
+```
+
+Use explicit HTML `<ul>`/`<li>` tags instead of markdown list markers (`*`, `-`). Markdown lists work when formatted correctly, but omitting the space after the marker (e.g., `-<span>` instead of `- <span>`) silently breaks the list parse, so HTML tags are more reliable.
+
+**Grouped suggestions:**
+```
+##### Explore the data
+<ul>
+<li><span class="suggestion">What tables are available?</span></li>
+<li><span class="suggestion">What columns does … have?</span></li>
+</ul>
+
+##### Analyze the data
+<ul>
+<li><span class="suggestion">What's the average …?</span></li>
+<li><span class="suggestion">How many …?</span></li>
+</ul>
+```
+
+#### Suggestion Guidelines
+
+- Use list format with 2–4 concrete, actionable suggestions grouped under `#####` headings
+- Write suggestions as complete, natural prompts (not fragments)
+- Include at least one suggestion encouraging the user to explore what data and questions are available
+- Never use nested lists for suggestions — group them under headings instead
+- Never use generic phrases like "If you'd like to..." — provide concrete suggestions
+- Never refer to suggestions as "prompts" — call them "suggestions" or "ideas" or similar

--- a/pkg-r/inst/prompts/greeting.md
+++ b/pkg-r/inst/prompts/greeting.md
@@ -1,6 +1,7 @@
 You are a friendly data assistant. Write a warm welcome greeting for a user who is about to explore their data.
 
-You have access to a {{db_type}} SQL database with the following tables:
+{{#has_tables}}
+You have access to a {{db_type}} database with the following tables:
 
 {{#has_data_dicts}}
 {{{data_dicts}}}
@@ -12,6 +13,11 @@ You have access to a {{db_type}} SQL database with the following tables:
 </tables>
 
 {{/has_data_dicts}}
+{{/has_tables}}
+{{^has_tables}}
+You have access to a {{db_type}} database.
+
+{{/has_tables}}
 {{#data_description}}
 <data_description>
 {{{data_description}}}

--- a/pkg-r/man/QueryChat.Rd
+++ b/pkg-r/man/QueryChat.Rd
@@ -286,7 +286,7 @@ Default is \code{FALSE}.}
       \item{\code{include_in_greeting}}{Whether to include added tables in the greeting
 context. \code{TRUE} includes all tables; \code{FALSE} (default) includes none;
 a character vector includes only those named tables (intersected with
-the tables being added).}
+the tables being added). Any other type raises an error.}
     }
     \if{html}{\out{</div>}}
   }

--- a/pkg-r/man/QueryChat.Rd
+++ b/pkg-r/man/QueryChat.Rd
@@ -109,6 +109,9 @@ qc <- QueryChat$new(con, "mtcars")
 \section{Active bindings}{
   \if{html}{\out{<div class="r6-active-bindings">}}
   \describe{
+    \item{\code{greeter}}{The QueryChatGreeter controlling greeting generation;
+access its \verb{$tables} and \verb{$prompt}.}
+
     \item{\code{system_prompt}}{Get the system prompt.}
 
     \item{\code{data_source}}{Removed. Use \verb{$add_table()} and \verb{$remove_table()} to manage tables.}
@@ -227,7 +230,12 @@ or \code{FALSE} to never clean up automatically.}
   Add a table to this QueryChat instance.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{QueryChat$add_table(data_source, table_name, replace = FALSE)}
+    \preformatted{QueryChat$add_table(
+  data_source,
+  table_name,
+  replace = FALSE,
+  include_in_greeting = FALSE
+)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -237,6 +245,8 @@ or \code{FALSE} to never clean up automatically.}
       \item{\code{table_name}}{The SQL table name for this data source.}
       \item{\code{replace}}{Whether to replace an existing table with this name.
 Default is \code{FALSE}.}
+      \item{\code{include_in_greeting}}{Whether to include this table in the greeting
+context. Default is \code{FALSE}.}
     }
     \if{html}{\out{</div>}}
   }
@@ -256,7 +266,12 @@ system prompt exactly once after all tables have been staged, avoiding
 N-1 spurious intermediate rebuilds.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{QueryChat$add_tables(conn, tables = NULL, replace = FALSE)}
+    \preformatted{QueryChat$add_tables(
+  conn,
+  tables = NULL,
+  replace = FALSE,
+  include_in_greeting = FALSE
+)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -268,6 +283,10 @@ individual data frames or other sources via \verb{$add_table()}.}
 by \code{DBI::dbListTables(conn)} are used.}
       \item{\code{replace}}{Whether to replace existing tables with the same name.
 Default is \code{FALSE}.}
+      \item{\code{include_in_greeting}}{Whether to include added tables in the greeting
+context. \code{TRUE} includes all tables; \code{FALSE} (default) includes none;
+a character vector includes only those named tables (intersected with
+the tables being added).}
     }
     \if{html}{\out{</div>}}
   }

--- a/pkg-r/tests/testthat/test-QueryChat.R
+++ b/pkg-r/tests/testthat/test-QueryChat.R
@@ -1188,6 +1188,48 @@ describe("QueryChatGreeter", {
     expect_false(grepl("CUSTOMERS_DICT_DESC", prompt))
   })
 
+  it("greeting prompt keeps a global dict description but drops relationships/glossary", {
+    conn <- local_multi_table_conn_greeter()
+    global_yaml <- withr::local_tempfile(fileext = ".yaml")
+    writeLines(
+      c(
+        "name: domain",
+        "description: GLOBAL_DOMAIN_DESC",
+        "glossary:",
+        "  ARR: GLOSSARY_ARR_DEF"
+      ),
+      global_yaml
+    )
+    orders_yaml <- withr::local_tempfile(fileext = ".yaml")
+    writeLines(
+      c(
+        "name: orders_dict",
+        "description: ORDERS_DICT_DESC",
+        "tables:",
+        "  orders:",
+        "    description: Orders info",
+        "relationships:",
+        "  - join: orders.id = customers.id",
+        "    description: REL_DESC"
+      ),
+      orders_yaml
+    )
+
+    qc <- QueryChat$new(
+      NULL,
+      "placeholder",
+      greeting = "hi",
+      data_dict = list(global_yaml, orders_yaml)
+    )
+    qc$add_tables(conn, include_in_greeting = "orders")
+
+    prompt <- qc$.__enclos_env__$private$build_greeting_client()$get_system_prompt()
+    expect_true(grepl("GLOBAL_DOMAIN_DESC", prompt))
+    expect_true(grepl("ORDERS_DICT_DESC", prompt))
+    expect_false(grepl("GLOSSARY_ARR_DEF", prompt))
+    expect_false(grepl("REL_DESC", prompt))
+  })
+
   it("generate_greeting() uses greeting system prompt, writes to qc$greeting, returns text", {
     client <- mock_ellmer_chat_client(
       public = list(

--- a/pkg-r/tests/testthat/test-QueryChat.R
+++ b/pkg-r/tests/testthat/test-QueryChat.R
@@ -1118,6 +1118,15 @@ describe("QueryChatGreeter", {
     expect_false("customers" %in% qc$greeter$tables)
   })
 
+  it("add_tables with non-logical, non-character include_in_greeting errors", {
+    conn <- local_multi_table_conn_greeter()
+    qc <- QueryChat$new(NULL, "placeholder", greeting = "hi")
+    expect_error(
+      suppressWarnings(qc$add_tables(conn, include_in_greeting = 1)),
+      "include_in_greeting"
+    )
+  })
+
   it("generate_greeting() uses greeting system prompt, writes to qc$greeting, returns text", {
     client <- mock_ellmer_chat_client(
       public = list(

--- a/pkg-r/tests/testthat/test-QueryChat.R
+++ b/pkg-r/tests/testthat/test-QueryChat.R
@@ -1136,6 +1136,44 @@ describe("QueryChatGreeter", {
     )
   })
 
+  it("greeting prompt omits dicts that describe only excluded tables", {
+    conn <- local_multi_table_conn_greeter()
+    orders_yaml <- withr::local_tempfile(fileext = ".yaml")
+    writeLines(
+      c(
+        "name: orders_dict",
+        "description: ORDERS_DICT_DESC",
+        "tables:",
+        "  orders:",
+        "    description: Orders info"
+      ),
+      orders_yaml
+    )
+    customers_yaml <- withr::local_tempfile(fileext = ".yaml")
+    writeLines(
+      c(
+        "name: customers_dict",
+        "description: CUSTOMERS_DICT_DESC",
+        "tables:",
+        "  customers:",
+        "    description: Customers info"
+      ),
+      customers_yaml
+    )
+
+    qc <- QueryChat$new(
+      NULL,
+      "placeholder",
+      greeting = "hi",
+      data_dict = list(orders_yaml, customers_yaml)
+    )
+    qc$add_tables(conn, include_in_greeting = "orders")
+
+    prompt <- qc$.__enclos_env__$private$build_greeting_client()$get_system_prompt()
+    expect_true(grepl("ORDERS_DICT_DESC", prompt))
+    expect_false(grepl("CUSTOMERS_DICT_DESC", prompt))
+  })
+
   it("generate_greeting() uses greeting system prompt, writes to qc$greeting, returns text", {
     client <- mock_ellmer_chat_client(
       public = list(

--- a/pkg-r/tests/testthat/test-QueryChat.R
+++ b/pkg-r/tests/testthat/test-QueryChat.R
@@ -1136,6 +1136,20 @@ describe("QueryChatGreeter", {
     )
   })
 
+  it("add_tables leaves state unchanged when include_in_greeting is invalid", {
+    conn <- local_multi_table_conn_greeter()
+    qc <- QueryChat$new(NULL, "placeholder", greeting = "hi")
+    expect_error(
+      suppressWarnings(qc$add_tables(conn, include_in_greeting = 1)),
+      "include_in_greeting"
+    )
+    expect_false("orders" %in% qc$greeter$tables)
+    expect_false("customers" %in% qc$greeter$tables)
+    suppressWarnings(qc$add_tables(conn, include_in_greeting = TRUE))
+    expect_true("orders" %in% qc$greeter$tables)
+    expect_true("customers" %in% qc$greeter$tables)
+  })
+
   it("greeting prompt omits dicts that describe only excluded tables", {
     conn <- local_multi_table_conn_greeter()
     orders_yaml <- withr::local_tempfile(fileext = ".yaml")

--- a/pkg-r/tests/testthat/test-QueryChat.R
+++ b/pkg-r/tests/testthat/test-QueryChat.R
@@ -1274,6 +1274,33 @@ describe("QueryChatGreeter", {
     expect_equal(qc$greeting, "Generic greeting with no tables.")
   })
 
+  it("greeting prompt keeps a global dict description with no tables included", {
+    global_yaml <- withr::local_tempfile(fileext = ".yaml")
+    writeLines(
+      c(
+        "name: domain",
+        "description: GLOBAL_DOMAIN_DESC",
+        "glossary:",
+        "  ARR: GLOSSARY_ARR_DEF"
+      ),
+      global_yaml
+    )
+
+    qc <- QueryChat$new(
+      new_test_df(),
+      "test_table",
+      greeting = "hi",
+      data_dict = list(global_yaml)
+    )
+    withr::defer(qc$cleanup())
+    qc$greeter$tables <- character()
+
+    prompt <- qc$.__enclos_env__$private$build_greeting_client()$get_system_prompt()
+    expect_true(grepl("GLOBAL_DOMAIN_DESC", prompt))
+    expect_false(grepl("GLOSSARY_ARR_DEF", prompt))
+    expect_false(grepl("following tables", prompt))
+  })
+
   it("remove_table prunes the table from greeter$tables", {
     conn <- local_multi_table_conn_greeter()
     qc <- QueryChat$new(NULL, "placeholder", greeting = "hi")

--- a/pkg-r/tests/testthat/test-QueryChat.R
+++ b/pkg-r/tests/testthat/test-QueryChat.R
@@ -1183,7 +1183,7 @@ describe("QueryChatGreeter", {
     )
     qc$add_tables(conn, include_in_greeting = "orders")
 
-    prompt <- qc$.__enclos_env__$private$build_greeting_client()$get_system_prompt()
+    prompt <- qc$greeter$build_client()$get_system_prompt()
     expect_true(grepl("ORDERS_DICT_DESC", prompt))
     expect_false(grepl("CUSTOMERS_DICT_DESC", prompt))
   })
@@ -1223,7 +1223,7 @@ describe("QueryChatGreeter", {
     )
     qc$add_tables(conn, include_in_greeting = "orders")
 
-    prompt <- qc$.__enclos_env__$private$build_greeting_client()$get_system_prompt()
+    prompt <- qc$greeter$build_client()$get_system_prompt()
     expect_true(grepl("GLOBAL_DOMAIN_DESC", prompt))
     expect_true(grepl("ORDERS_DICT_DESC", prompt))
     expect_false(grepl("GLOSSARY_ARR_DEF", prompt))
@@ -1243,7 +1243,7 @@ describe("QueryChatGreeter", {
     qc <- QueryChat$new(new_test_df(), "test_table", client = client)
     withr::defer(qc$cleanup())
 
-    greeting_client <- qc$.__enclos_env__$private$build_greeting_client()
+    greeting_client <- qc$greeter$build_client()
     greeting_system_prompt <- greeting_client$get_system_prompt()
     expect_false(grepl("querychat_get_schema", greeting_system_prompt))
     expect_true(grepl("test_table", greeting_system_prompt))
@@ -1266,7 +1266,7 @@ describe("QueryChatGreeter", {
 
     qc$greeter$tables <- character()
 
-    prompt <- qc$.__enclos_env__$private$build_greeting_client()$get_system_prompt()
+    prompt <- qc$greeter$build_client()$get_system_prompt()
     expect_false(grepl("following tables", prompt))
     expect_false(grepl("SQL SQL", prompt))
 
@@ -1295,7 +1295,7 @@ describe("QueryChatGreeter", {
     withr::defer(qc$cleanup())
     qc$greeter$tables <- character()
 
-    prompt <- qc$.__enclos_env__$private$build_greeting_client()$get_system_prompt()
+    prompt <- qc$greeter$build_client()$get_system_prompt()
     expect_true(grepl("GLOBAL_DOMAIN_DESC", prompt))
     expect_false(grepl("GLOSSARY_ARR_DEF", prompt))
     expect_false(grepl("following tables", prompt))

--- a/pkg-r/tests/testthat/test-QueryChat.R
+++ b/pkg-r/tests/testthat/test-QueryChat.R
@@ -1039,3 +1039,121 @@ describe("QueryChat$add_tables()", {
     expect_length(multi_table_warns, 1L)
   })
 })
+
+describe("QueryChatGreeter", {
+  skip_if_no_dataframe_engine()
+
+  local_multi_table_conn_greeter <- function(env = parent.frame()) {
+    skip_if_not_installed("RSQLite")
+    conn <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
+    withr::defer(DBI::dbDisconnect(conn), envir = env)
+    DBI::dbWriteTable(
+      conn,
+      "orders",
+      data.frame(id = 1:2, amount = c(9.99, 4.50))
+    )
+    DBI::dbWriteTable(
+      conn,
+      "customers",
+      data.frame(id = 1:2, name = c("Alice", "Bob"))
+    )
+    conn
+  }
+
+  it("constructor table is always present in greeter$tables", {
+    qc <- local_querychat(new_test_df(), "test_table", greeting = "hi")
+    expect_true("test_table" %in% qc$greeter$tables)
+  })
+
+  it("user-supplied greeting survives construction and mutation of greeter fields", {
+    qc <- local_querychat(
+      new_test_df(),
+      "test_table",
+      greeting = "Preset greeting"
+    )
+    expect_equal(qc$greeting, "Preset greeting")
+
+    qc$greeter$tables <- c("test_table", "other")
+    expect_equal(qc$greeting, "Preset greeting")
+
+    qc$greeter$prompt <- "New prompt text"
+    expect_equal(qc$greeting, "Preset greeting")
+  })
+
+  it("add_table with include_in_greeting = TRUE adds to greeter$tables", {
+    qc <- local_querychat(new_test_df(), "base_table", greeting = "hi")
+    extra <- new_test_df()
+    qc$add_table(extra, "extra_table", include_in_greeting = TRUE)
+    expect_true("extra_table" %in% qc$greeter$tables)
+  })
+
+  it("add_table with default include_in_greeting does NOT add to greeter$tables", {
+    qc <- local_querychat(new_test_df(), "base_table", greeting = "hi")
+    extra <- new_test_df()
+    qc$add_table(extra, "hidden_table")
+    expect_false("hidden_table" %in% qc$greeter$tables)
+  })
+
+  it("add_tables with include_in_greeting = TRUE adds all tables", {
+    conn <- local_multi_table_conn_greeter()
+    qc <- QueryChat$new(NULL, "placeholder", greeting = "hi")
+    suppressWarnings(qc$add_tables(conn, include_in_greeting = TRUE))
+    expect_true("orders" %in% qc$greeter$tables)
+    expect_true("customers" %in% qc$greeter$tables)
+  })
+
+  it("add_tables with include_in_greeting = FALSE adds no tables to greeter", {
+    conn <- local_multi_table_conn_greeter()
+    qc <- QueryChat$new(NULL, "placeholder", greeting = "hi")
+    suppressWarnings(qc$add_tables(conn, include_in_greeting = FALSE))
+    expect_false("orders" %in% qc$greeter$tables)
+    expect_false("customers" %in% qc$greeter$tables)
+  })
+
+  it("add_tables with include_in_greeting as character includes only named subset", {
+    conn <- local_multi_table_conn_greeter()
+    qc <- QueryChat$new(NULL, "placeholder", greeting = "hi")
+    suppressWarnings(qc$add_tables(conn, include_in_greeting = "orders"))
+    expect_true("orders" %in% qc$greeter$tables)
+    expect_false("customers" %in% qc$greeter$tables)
+  })
+
+  it("generate_greeting() uses greeting system prompt, writes to qc$greeting, returns text", {
+    client <- mock_ellmer_chat_client(
+      public = list(
+        chat = function(message, ...) {
+          expect_equal(message, GREETING_PROMPT)
+          "Hello from greeting mock!"
+        }
+      )
+    )
+
+    qc <- QueryChat$new(new_test_df(), "test_table", client = client)
+    withr::defer(qc$cleanup())
+
+    greeting_client <- qc$.__enclos_env__$private$build_greeting_client()
+    greeting_system_prompt <- greeting_client$get_system_prompt()
+    expect_false(grepl("querychat_get_schema", greeting_system_prompt))
+    expect_true(grepl("test_table", greeting_system_prompt))
+
+    result <- qc$generate_greeting()
+
+    expect_equal(result, "Hello from greeting mock!")
+    expect_equal(qc$greeting, "Hello from greeting mock!")
+  })
+
+  it("generate_greeting() with empty greeter$tables succeeds without error", {
+    client <- mock_ellmer_chat_client(
+      public = list(
+        chat = function(message, ...) "Generic greeting with no tables."
+      )
+    )
+
+    qc <- QueryChat$new(new_test_df(), "test_table", client = client)
+    withr::defer(qc$cleanup())
+
+    qc$greeter$tables <- character()
+    expect_no_error(qc$generate_greeting())
+    expect_equal(qc$greeting, "Generic greeting with no tables.")
+  })
+})

--- a/pkg-r/tests/testthat/test-QueryChat.R
+++ b/pkg-r/tests/testthat/test-QueryChat.R
@@ -1094,6 +1094,15 @@ describe("QueryChatGreeter", {
     expect_false("hidden_table" %in% qc$greeter$tables)
   })
 
+  it("add_table with non-logical include_in_greeting errors", {
+    qc <- local_querychat(new_test_df(), "base_table", greeting = "hi")
+    extra <- new_test_df()
+    expect_error(
+      qc$add_table(extra, "extra_table", include_in_greeting = "yes"),
+      "include_in_greeting"
+    )
+  })
+
   it("add_tables with include_in_greeting = TRUE adds all tables", {
     conn <- local_multi_table_conn_greeter()
     qc <- QueryChat$new(NULL, "placeholder", greeting = "hi")

--- a/pkg-r/tests/testthat/test-QueryChat.R
+++ b/pkg-r/tests/testthat/test-QueryChat.R
@@ -1209,7 +1209,23 @@ describe("QueryChatGreeter", {
     withr::defer(qc$cleanup())
 
     qc$greeter$tables <- character()
+
+    prompt <- qc$.__enclos_env__$private$build_greeting_client()$get_system_prompt()
+    expect_false(grepl("following tables", prompt))
+    expect_false(grepl("SQL SQL", prompt))
+
     expect_no_error(qc$generate_greeting())
     expect_equal(qc$greeting, "Generic greeting with no tables.")
+  })
+
+  it("remove_table prunes the table from greeter$tables", {
+    conn <- local_multi_table_conn_greeter()
+    qc <- QueryChat$new(NULL, "placeholder", greeting = "hi")
+    suppressWarnings(qc$add_tables(conn, include_in_greeting = TRUE))
+    expect_true("orders" %in% qc$greeter$tables)
+
+    qc$remove_table("orders")
+    expect_false("orders" %in% qc$greeter$tables)
+    expect_true("customers" %in% qc$greeter$tables)
   })
 })

--- a/pkg-r/vignettes/greet.Rmd
+++ b/pkg-r/vignettes/greet.Rmd
@@ -77,3 +77,37 @@ querychat_app(
   greeting = "penguins_greeting.md"
 )
 ```
+
+## Greetings with multiple tables
+
+The generated greeting is *schema-aware*: querychat shares the schema of the
+relevant tables with the model so the opening message can describe the data
+it's about to help you explore. Tables passed to `QueryChat$new()` are included
+in the greeting automatically.
+
+Tables added later with `$add_table()` or `$add_tables()` are **not** included
+by default — pass `include_in_greeting = TRUE` to opt them in:
+
+```{r}
+qc <- QueryChat$new(orders, "orders")             # included automatically
+qc$add_table(customers, "customers")              # not included by default
+qc$add_table(products, "products", include_in_greeting = TRUE)  # opted in
+
+qc$greeter$tables
+#> [1] "orders"   "products"
+```
+
+For `$add_tables()`, `include_in_greeting` can also be a character vector
+naming which of the added tables to include:
+
+```{r}
+qc$add_tables(con, include_in_greeting = c("orders", "customers"))
+```
+
+You can also set the included tables directly, or swap in a custom greeting
+template, through `qc$greeter`:
+
+```{r}
+qc$greeter$tables <- c("orders", "customers")
+qc$greeter$prompt <- "my-greeting-template.md"
+```


### PR DESCRIPTION
Supersedes the constructor-based approach in #260 (kept open for discussion). Credit to @cpsievert for the regression insight and test infrastructure.

## Summary

After multi-table support (#195), the schema moved out of the system prompt into a lazy `tool_get_schema` tool. Greetings are generated by a tool-free client, so the model became schema-blind when writing the opening message — it could no longer describe the data it was about to chat about.

This PR fixes that with a dedicated greeting API rather than a constructor parameter. The greeting-specific concern lives on a new semi-internal `QueryChatGreeter`, reached via `qc$greeter` (R) / `qc.greeter` (Python), instead of widening the `QueryChat` constructor for every single-table user.

Key design decisions:

- **`QueryChatGreeter`** holds `$tables` (table names whose schema to embed in the greeting) and `$prompt` (the greeting template). It is semi-internal — accessed through `qc.greeter`, not separately constructed (R class is `@noRd`). Setters store only; changing greeter config never invalidates an existing `qc$greeting`, so a user-supplied static greeting always survives.
- **Separate greeting system prompt** (`greeting.md`) instead of the full `prompt.md`. The greeting client no longer receives SQL guidelines or tool descriptions — just the schema for the selected tables, the data description, and suggestion-card syntax. The greeter owns greeting-client construction via `build_client()`, `generate()` (sync), and `generate_stream()` (async/Shiny).
- **`QueryChatSystemPrompt` gained granular include flags** — `include_tables`, `include_relationships`, `include_glossary` — so the greeting path can request a scoped prompt without inline filtering. The multi-table-no-dict warning fires only on the session path; greetings never re-warn.
- **Constructor tables are always included** in the greeting; `add_table(include_in_greeting=)` / `add_tables(include_in_greeting=)` opt additional tables in (default off). `add_tables` accepts a logical/`bool` or a character vector / `list[str]` of names.
- **Greeting data dicts are scoped** to the included tables: per-table entries are filtered, and table-less global dicts keep their description but drop cross-table relationships/glossary, so a curated greeting subset can't leak excluded-table metadata.
- **Greetings generate on a separate, throwaway client** in every backend (Shiny, Streamlit, Gradio, Dash). The shared `qc.greeting` is written only by an explicit `generate_greeting()` / `greeter.generate()`; in-app greetings stay session-local.
- **Client resolution is split from cloning** (Python). `resolve_client()` turns a spec into a `Chat` object (done once at init); `create_client()` cheaply clones it per session/greeting. Invalid provider strings now fail at init instead of at first session.

The Python and R implementations mirror each other. `generate_greeting()` is kept as a thin wrapper over `greeter.generate()`, so existing callers need no changes.

## Verification

Tables passed to the constructor are automatically included in the greeting. Tables added later with `add_table()` are **not** included by default — pass `include_in_greeting = TRUE` to opt them in.

R:

```r
library(querychat)
qc <- QueryChat$new(mtcars, "mtcars")
# Constructor table is included in the greeting automatically
qc$greeter$tables
#> [1] "mtcars"

# add_table() does NOT include the table in the greeting by default
qc$add_table(flights, "flights")
qc$greeter$tables
#> [1] "mtcars"

# ...opt it in explicitly
qc$add_table(airports, "airports", include_in_greeting = TRUE)
qc$greeter$tables
#> [1] "mtcars"   "airports"

greeting <- qc$generate_greeting()  # builds a lean, schema-aware greeting client
```

Python:

```python
from querychat import QueryChat
qc = QueryChat(data_source=df, table_name="mtcars")
qc.greeter.tables          # ['mtcars'] -- constructor table auto-included

# add_table() does NOT include the table in the greeting by default
qc.add_table(flights, "flights")
qc.greeter.tables          # ['mtcars']

# ...opt it in explicitly
qc.add_table(airports, "airports", include_in_greeting=True)
qc.greeter.tables          # ['mtcars', 'airports']

# add_tables() takes a list of names to include a subset
qc.add_tables(engine, include_in_greeting=["orders", "customers"])

qc.generate_greeting()     # schema-aware greeting on a separate client
```