### PR TITLE
fix(pkg-r): Hide close button in $app() when non-interactive

### DIFF
--- a/pkg-r/NEWS.md
+++ b/pkg-r/NEWS.md
@@ -39,6 +39,8 @@
 
 * Fixed `data_description` and `extra_instructions` being HTML-escaped in the system prompt. Special characters like `<`, `>`, and `&` in developer-provided descriptions and instructions are now passed to the LLM verbatim. (#258)
 
+* The close button in `$app()` is now hidden when running in a non-interactive context (e.g. a deployed Shiny app), preventing `stopApp()` from crashing the session for other users. (#259)
+
 # querychat 0.3.0
 
 ## New features

--- a/pkg-r/R/QueryChat.R
+++ b/pkg-r/R/QueryChat.R
@@ -705,12 +705,14 @@ QueryChat <- R6::R6Class(
             ),
             DT::DTOutput("dt")
           ),
-          shiny::actionButton(
-            "close_btn",
-            label = "",
-            class = "btn-close",
-            style = "position: fixed; top: 6px; right: 6px;"
-          )
+          if (rlang::is_interactive()) {
+            shiny::actionButton(
+              "close_btn",
+              label = "",
+              class = "btn-close",
+              style = "position: fixed; top: 6px; right: 6px;"
+            )
+          }
         )
       }
 
@@ -777,17 +779,19 @@ QueryChat <- R6::R6Class(
           )
         })
 
-        shiny::observeEvent(input$close_btn, label = "on_close_btn", {
-          name <- active_table_name()
-          shiny::stopApp(
-            list(
-              df = qc_vals$.tables[[name]]$df(),
-              sql = qc_vals$.tables[[name]]$sql(),
-              title = qc_vals$.tables[[name]]$title(),
-              client = qc_vals$client
+        if (rlang::is_interactive()) {
+          shiny::observeEvent(input$close_btn, label = "on_close_btn", {
+            name <- active_table_name()
+            shiny::stopApp(
+              list(
+                df = qc_vals$.tables[[name]]$df(),
+                sql = qc_vals$.tables[[name]]$sql(),
+                title = qc_vals$.tables[[name]]$title(),
+                client = qc_vals$client
+              )
             )
-          )
-        })
+          })
+        }
       }
 
       shiny::shinyApp(ui, server, enableBookmarking = bookmark_store)


### PR DESCRIPTION
Closes #259

## Summary

`$app()` renders a fixed close button that calls `shiny::stopApp()` when clicked. In a deployed app, `stopApp()` crashes the session for all users. This fix gates both the button (UI) and the `observeEvent` (server) on `rlang::is_interactive()`, so neither exists when the app is running in a non-interactive context such as a deployed Shiny app.

## Verification

Run `querychat(ames)` from an interactive R session — the close button appears in the top-right corner and clicking it returns the result as before. In a deployed app the button is absent.