### PR TITLE
docs: drop stale GitHub model marketplace callout

### DIFF
--- a/pkg-py/docs/models.qmd
+++ b/pkg-py/docs/models.qmd
@@ -38,15 +38,15 @@ client = ChatAnthropic(model="claude-sonnet-4-5")
 Most models require an API key or some other form of authentication. See the reference page for the relevant [model provider](https://posit-dev.github.io/chatlas/get-started/models.html)  (e.g., [ChatAnthropic](https://posit-dev.github.io/chatlas/reference/ChatAnthropic.html)) to learn more on how to set up credentials.
 
 ::: callout-tip
-### Free tier options
+### Free trial options
 
-If you don't want to spend any money to get started, [ChatGoogle](https://posit-dev.github.io/chatlas/reference/ChatGoogle.html) offers a generous free tier.
+If you don't want to spend any money to get started, [ChatPosit](https://posit-dev.github.io/chatlas/reference/ChatPosit.html) provides free trial access to a curated set of models through the [Posit AI](https://posit.ai) gateway.
 
-```{.python filename="google-model.py"}
-from chatlas import ChatGoogle
+```{.python filename="posit-model.py"}
+from chatlas import ChatPosit
 
-# Just works if GOOGLE_API_KEY is set in your environment
-client = ChatGoogle()
+# Prompts you to log in via OAuth the first time; tokens are then cached
+client = ChatPosit()
 ```
 :::
 

--- a/pkg-py/docs/models.qmd
+++ b/pkg-py/docs/models.qmd
@@ -38,15 +38,15 @@ client = ChatAnthropic(model="claude-sonnet-4-5")
 Most models require an API key or some other form of authentication. See the reference page for the relevant [model provider](https://posit-dev.github.io/chatlas/get-started/models.html)  (e.g., [ChatAnthropic](https://posit-dev.github.io/chatlas/reference/ChatAnthropic.html)) to learn more on how to set up credentials.
 
 ::: callout-tip
-### Github model marketplace
+### Free tier options
 
-If you are already setup with Github credentials, [Github model marketplace](https://github.com/marketplace/models) provides a free and easy way to get started. See [here](https://posit-dev.github.io/chatlas/reference/ChatGithub.html) for more details on how to get setup.
+If you don't want to spend any money to get started, [ChatGoogle](https://posit-dev.github.io/chatlas/reference/ChatGoogle.html) offers a generous free tier.
 
-```{.python filename="github-model.py"}
-from chatlas import ChatGithub
+```{.python filename="google-model.py"}
+from chatlas import ChatGoogle
 
-# Just works if GITHUB_TOKEN is set in your environment
-client = ChatGithub(model="gpt-4.1")
+# Just works if GOOGLE_API_KEY is set in your environment
+client = ChatGoogle()
 ```
 :::
 

--- a/pkg-r/tests/testthat/_snaps/QueryChat.md
+++ b/pkg-r/tests/testthat/_snaps/QueryChat.md
@@ -47,8 +47,6 @@
         expect_s3_class(captured, "chat_history_config")
         expect_equal(captured$restore_mode, "bookmark")
       })
-    Message
-      Using model = "gpt-4.1".
     Condition
       Warning:
       The `enable_bookmarking` argument of `QueryChat$server()` is deprecated as of querychat 0.4.0.

--- a/pkg-r/tests/testthat/test-QueryChat.R
+++ b/pkg-r/tests/testthat/test-QueryChat.R
@@ -752,7 +752,7 @@ test_that("QueryChat$server() resolves history (explicit > constructor > TRUE) a
     }
   )
 
-  qc_no_history <- local_querychat()
+  qc_no_history <- local_querychat(client = mock_ellmer_chat_client())
   qc_no_history$.__enclos_env__$private$.query_executor <- executor
   shiny::testServer(
     function(input, output, session) qc_no_history$server(),

--- a/pkg-r/vignettes/models.Rmd
+++ b/pkg-r/vignettes/models.Rmd
@@ -52,15 +52,15 @@ qc$app()  # Launch the app
 Most models require an API key or some other form of authentication. See the reference page for the relevant model provider (e.g., [`chat_anthropic()`](https://ellmer.tidyverse.org/reference/chat_anthropic.html)) to learn more on how to set up credentials.
 
 ::: {.alert .alert-info}
-**Free tier options**
+**Free trial options**
 
-If you don't want to spend any money to get started, [`chat_google_gemini()`](https://ellmer.tidyverse.org/reference/chat_google_gemini.html) offers a generous free tier.
+If you don't want to spend any money to get started, [`chat_posit()`](https://ellmer.tidyverse.org/reference/chat_posit.html) provides free trial access to a curated set of models through the [Posit AI](https://posit.ai) gateway.
 
 ```{r}
 library(ellmer)
 
-# Just works if GOOGLE_API_KEY is set in your environment
-client <- chat_google_gemini()
+# Prompts you to log in via OAuth the first time; tokens are then cached
+client <- chat_posit()
 ```
 :::
 

--- a/pkg-r/vignettes/models.Rmd
+++ b/pkg-r/vignettes/models.Rmd
@@ -52,15 +52,15 @@ qc$app()  # Launch the app
 Most models require an API key or some other form of authentication. See the reference page for the relevant model provider (e.g., [`chat_anthropic()`](https://ellmer.tidyverse.org/reference/chat_anthropic.html)) to learn more on how to set up credentials.
 
 ::: {.alert .alert-info}
-**GitHub model marketplace**
+**Free tier options**
 
-If you are already setup with GitHub credentials, [GitHub model marketplace](https://github.com/marketplace/models) provides a free and easy way to get started. See [here](https://ellmer.tidyverse.org/reference/chat_github.html) for more details on how to get setup.
+If you don't want to spend any money to get started, [`chat_google_gemini()`](https://ellmer.tidyverse.org/reference/chat_google_gemini.html) offers a generous free tier.
 
 ```{r}
 library(ellmer)
 
-# Just works if GITHUB_TOKEN is set in your environment
-client <- chat_github(model = "gpt-4.1")
+# Just works if GOOGLE_API_KEY is set in your environment
+client <- chat_google_gemini()
 ```
 :::
 


### PR DESCRIPTION
## Summary

GitHub Models was [retired on 2026-07-30](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/), so `chatlas.ChatGithub()` / `ellmer::chat_github()` now always raise (see [chatlas#378](https://github.com/posit-dev/chatlas/pull/378) and [ellmer#1072](https://github.com/tidyverse/ellmer/pull/1072)). The "Github model marketplace" credential callouts in both models docs pages recommended it as a free way to get started, which no longer works.

Replaced both callouts with a pointer to Posit AI's free trial (`ChatPosit()` / `chat_posit()`) instead — it's the first-party option and works out of the box via an OAuth device flow, with no API key to manage.

## Test plan

- [x] Grepped the repo for other `ChatGithub`/`chat_github`/GitHub-model-marketplace references — none remain.