### PR TITLE
fix(r): support ellmer 0.5.0's Provider/Model API in test mocks

### DIFF
--- a/pkg-r/tests/testthat/apps/basic/app.R
+++ b/pkg-r/tests/testthat/apps/basic/app.R
@@ -24,12 +24,27 @@ dbDisconnect(conn)
 # Setup database source and QueryChat instance
 db_conn <- dbConnect(RSQLite::SQLite(), temp_db)
 
+# ellmer 0.5.0 moved model details out of `Provider` and into a new `Model`
+# class: `Provider()` no longer takes `model` as its second positional
+# argument, and `Chat$new()` now requires a separate `model` argument. `Model`
+# doesn't exist before 0.5.0, so branch on its presence to support both.
+mock_chat_client <- if (
+  exists("Model", where = asNamespace("ellmer"), inherits = FALSE)
+) {
+  MockChat$new(
+    ellmer::Provider("test", "test"),
+    model = ellmer::Model(name = "test")
+  )
+} else {
+  MockChat$new(ellmer::Provider("test", "test", "test"))
+}
+
 # Create QueryChat instance
 qc <- QueryChat$new(
   data_source = db_conn,
   table_name = "iris",
   greeting = "Welcome to the test app!",
-  client = MockChat$new(ellmer::Provider("test", "test", "test"))
+  client = mock_chat_client
 )
 
 ui <- page_sidebar(

--- a/pkg-r/tests/testthat/helper-fixtures.R
+++ b/pkg-r/tests/testthat/helper-fixtures.R
@@ -173,7 +173,23 @@ mock_ellmer_chat_client <- function(
     private = private
   )
 
-  MockChat$new(ellmer::Provider("test", "test", "test"))
+  new_mock_chat(MockChat)
+}
+
+# ellmer 0.5.0 moved model details out of `Provider` and into a new `Model`
+# class: `Provider()` no longer takes `model` as its second positional
+# argument, and `Chat$new()` now requires a separate `model` argument. `Model`
+# doesn't exist before 0.5.0, so branch on its presence to support both.
+new_mock_chat <- function(MockChat, ...) {
+  if (exists("Model", where = asNamespace("ellmer"), inherits = FALSE)) {
+    MockChat$new(
+      ellmer::Provider("test", "test"),
+      model = ellmer::Model(name = "test"),
+      ...
+    )
+  } else {
+    MockChat$new(ellmer::Provider("test", "test", "test"), ...)
+  }
 }
 
 # shinychat::chat_restore() validates that `client` is an ellmer::Chat() R6


### PR DESCRIPTION
Fixes #283.

ellmer 0.5.0 moves model details from `Provider` into a new `Model` class: `Provider()` no longer takes `model` as its second positional argument, and `Chat$new()` now requires a separate `model` argument. This broke two test fixtures that constructed `MockChat$new(ellmer::Provider("test", "test", "test"))`:

- `tests/testthat/helper-fixtures.R` — `mock_ellmer_chat_client()`
- `tests/testthat/apps/basic/app.R`

This PR adds a version-agnostic construction that branches on whether `ellmer::Model` exists, so the mocks work on both old (≤ 0.4.2) and new (≥ 0.5.0) ellmer:

- On ≥ 0.5.0: `MockChat$new(ellmer::Provider("test", "test"), model = ellmer::Model(name = "test"))`
- On < 0.5.0: `MockChat$new(ellmer::Provider("test", "test", "test"))`

Both previously-failing test files (`test-QueryChat.R`, `test-querychat_module.R`) now pass with dev ellmer installed locally. The 4 `TblSqlSource` failures seen in a full `devtools::test()` run are pre-existing (a duckdb/dbplyr CTE-naming issue) and fail identically on `main`, so they're out of scope here.
