### PR TITLE
fix(py): constrain sqlglot<30.18.0 to work around Drop SQL regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,11 @@ polars = ["polars", "pyarrow<25.0.0"] # duckdb requires pyarrow for polars DataF
 ibis = [
     "ibis-framework>=9.0.0",
     "pandas", # required for ibis .execute() to return DataFrames
-    # sqlglot 30.18.0 regressed Drop SQL generation (omits the object name,
-    # e.g. `DROP VIEW IF EXISTS` with no name), breaking ibis's duckdb
-    # create_table(). Remove once fixed upstream (tobymao/sqlglot).
+    # sqlglot 30.18.0 deliberately renamed Drop.this -> Drop.tables
+    # (tobymao/sqlglot#8229), so ibis's Drop(this=...) calls emit e.g.
+    # `DROP VIEW IF EXISTS` with no name, breaking ibis's duckdb
+    # create_table(). Remove once fixed upstream:
+    # https://github.com/ibis-project/ibis/issues/12101
     "sqlglot<30.18.0",
 ]
 pins = ["pins>=0.9.1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,14 @@ classifiers = [
 # For SQLAlchemySource and sample data, one of polars or pandas is required
 pandas = ["pandas"]
 polars = ["polars", "pyarrow<25.0.0"] # duckdb requires pyarrow for polars DataFrame registration; pyarrow>=25.0.0 segfaults when its native conversion code runs on more than ~2 OS threads over a process's lifetime (e.g. Streamlit reruns each script on a fresh thread) -- see #268
-ibis = ["ibis-framework>=9.0.0", "pandas"]  # pandas required for ibis .execute() to return DataFrames
+ibis = [
+    "ibis-framework>=9.0.0",
+    "pandas", # required for ibis .execute() to return DataFrames
+    # sqlglot 30.18.0 regressed Drop SQL generation (omits the object name,
+    # e.g. `DROP VIEW IF EXISTS` with no name), breaking ibis's duckdb
+    # create_table(). Remove once fixed upstream (tobymao/sqlglot).
+    "sqlglot<30.18.0",
+]
 pins = ["pins>=0.9.1"]
 # Web framework extras
 streamlit = ["streamlit>=1.30"]
@@ -103,6 +110,8 @@ dev = [
     "polars>=1.0.0",
     "pyarrow<25.0.0", # see comment on the `polars` extra above
     "ibis-framework[duckdb]>=9.0.0",
+    # see note on the `ibis` extra above
+    "sqlglot<30.18.0",
     "ggsql>=0.3.2",
     "altair>=6.0",
     "shinywidgets>=0.8.0",


### PR DESCRIPTION
## Problem

CI's Python test jobs started failing with 48 ibis/duckdb-related test failures/errors, all with:

```
_duckdb.ParserException: Parser Error: syntax error at end of input
```

(e.g. [this run](https://github.com/posit-dev/querychat/actions/runs/34255143465) on #245). These failures are **orthogonal to the changes in those PRs** — they occur in ibis test fixtures (`conn.create_table(...)`) that no branch code touches.

## Root cause

Diffing the installed package set between the last passing run on `main` (2026-09-01) and the failing runs shows the relevant change is **sqlglot 30.17.0 → 30.18.0** (duckdb 1.5.5 and ibis-framework 12.0.0 are identical in both).

sqlglot 30.18.0 regressed SQL generation for `Drop` expressions: the object name is omitted entirely —

```python
import sqlglot.expressions as sge
sge.Drop(kind="VIEW", this="myview", exists=True).sql("duckdb")
# sqlglot 30.17.0: 'DROP VIEW IF EXISTS "myview"'
# sqlglot 30.18.0: 'DROP VIEW IF EXISTS'   <- name missing
```

ibis's duckdb backend issues exactly such a `DROP VIEW IF EXISTS` in `create_table()` when populating a table from an in-memory object ([ibis/backends/duckdb/\_\_init\_\_.py:239](https://github.com/ibis-project/ibis/blob/12.0.0/ibis/backends/duckdb/__init__.py#L239)), and duckdb rejects the truncated statement with the parser error above.

## Fix

Constrain `sqlglot<30.18.0` in the `ibis` extra and the `dev` dependency group, with a comment to remove the pin once the regression is fixed upstream (tobymao/sqlglot).

## Verification

- Reproduced the failure locally with duckdb 1.5.5 + ibis-framework 12.0.0 + sqlglot 30.18.0; confirmed it passes with sqlglot 30.17.0.
- With this constraint applied, `uv run pytest pkg-py/tests --ignore=pkg-py/tests/playwright` passes: **639 passed** (previously 12 failed + 36 errors).

This should also unblock #245 and #286, whose Python test failures have this same cause.