### PR TITLE
refactor: inject querychat extras via shinychat's footer slot

### DIFF
--- a/js/build.mjs
+++ b/js/build.mjs
@@ -36,6 +36,14 @@ const jsTargets = [
 
 const cssTargets = [
   {
+    source: "src/styles.css",
+    output: "../pkg-py/src/querychat/static/css/styles.css",
+  },
+  {
+    source: "src/styles.css",
+    output: "../pkg-r/inst/htmldep/styles.css",
+  },
+  {
     source: "src/viz.css",
     output: "../pkg-py/src/querychat/static/css/viz.css",
   },

--- a/js/src/handoff.css
+++ b/js/src/handoff.css
@@ -141,6 +141,12 @@
   padding: 0;
 }
 
+/* shinychat re-adopts the chat footer into its React tree at page load, which
+   double-initializes this editor; the live instance is the last one. */
+.querychat-handoff-panel-body .code-editor > *:not(:last-child) {
+  display: none;
+}
+
 .querychat-handoff-panel-body .ace_editor {
   height: 100% !important;
 }

--- a/js/src/styles.css
+++ b/js/src/styles.css
@@ -19,3 +19,10 @@
 .shiny-chat-footer:has(> .querychat-extras:only-child) {
     padding: 0 0 var(--shiny-chat-input-padding-bottom, var(--_chat-container-padding, .25rem));
 }
+
+/* The footer centers its own content (the message composer); reset that for
+   querychat's extras so the handoff panel and other footer-injected UI don't
+   inherit center alignment. */
+.querychat-extras {
+    text-align: left;
+}

--- a/js/src/styles.css
+++ b/js/src/styles.css
@@ -1,4 +1,3 @@
-/* Generated file. Source: js/src/styles.css. Do not edit directly. */
 .querychat shiny-chat-message table td,
 .querychat shiny-chat-message table th {
   border: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color);

--- a/pkg-py/src/querychat/_shiny_module.py
+++ b/pkg-py/src/querychat/_shiny_module.py
@@ -73,24 +73,24 @@ class TableState(Generic[IntoFrameT]):
 @module.ui
 def mod_ui(*, preload_viz: bool = False, **kwargs):
     return shinychat.chat_ui(
-        CHAT_ID, **_add_footer_and_class(kwargs, preload_viz=preload_viz)
+        CHAT_ID, **add_footer_and_class(kwargs, preload_viz=preload_viz)
     )
 
 
-def _querychat_extras(*, preload_viz: bool):
+def querychat_extras(*, preload_viz: bool):
     # The footer is the only child-injection point in chat_ui();
     # styles.css collapses it when it holds only these extras.
     return ui.div(
-        _querychat_head_content(),
+        querychat_head_content(),
         handoff_panel_ui(),
         preload_viz_deps_ui() if preload_viz else None,
         class_="querychat-extras",
     )
 
 
-def _add_footer_and_class(kwargs: dict, *, preload_viz: bool) -> dict:
+def add_footer_and_class(kwargs: dict, *, preload_viz: bool) -> dict:
     user_footer = kwargs.pop("footer", None)
-    extras = _querychat_extras(preload_viz=preload_viz)
+    extras = querychat_extras(preload_viz=preload_viz)
     kwargs["footer"] = (
         ui.TagList(user_footer, extras) if user_footer is not None else extras
     )
@@ -99,7 +99,7 @@ def _add_footer_and_class(kwargs: dict, *, preload_viz: bool) -> dict:
     return kwargs
 
 
-def _querychat_head_content():
+def querychat_head_content():
     css_path = Path(__file__).parent / "static" / "css" / "styles.css"
     js_path = Path(__file__).parent / "static" / "js" / "querychat.js"
     return ui.head_content(

--- a/pkg-py/src/querychat/_shiny_module.py
+++ b/pkg-py/src/querychat/_shiny_module.py
@@ -72,22 +72,39 @@ class TableState(Generic[IntoFrameT]):
 
 @module.ui
 def mod_ui(*, preload_viz: bool = False, **kwargs):
-    css_path = Path(__file__).parent / "static" / "css" / "styles.css"
-    js_path = Path(__file__).parent / "static" / "js" / "querychat.js"
+    return shinychat.chat_ui(
+        CHAT_ID, **_add_footer_and_class(kwargs, preload_viz=preload_viz)
+    )
 
-    kwargs.setdefault("enable_cancel", True)
-    kwargs.setdefault("allow_attachments", True)
-    tag = shinychat.chat_ui(CHAT_ID, **kwargs)
-    tag.add_class("querychat")
 
-    return ui.TagList(
-        ui.head_content(
-            ui.include_css(css_path),
-            ui.include_js(js_path),
-        ),
-        tag,
+def _querychat_extras(*, preload_viz: bool):
+    # The footer is the only child-injection point in chat_ui();
+    # styles.css collapses it when it holds only these extras.
+    return ui.div(
+        _querychat_head_content(),
         handoff_panel_ui(),
         preload_viz_deps_ui() if preload_viz else None,
+        class_="querychat-extras",
+    )
+
+
+def _add_footer_and_class(kwargs: dict, *, preload_viz: bool) -> dict:
+    user_footer = kwargs.pop("footer", None)
+    extras = _querychat_extras(preload_viz=preload_viz)
+    kwargs["footer"] = (
+        ui.TagList(user_footer, extras) if user_footer is not None else extras
+    )
+    user_class = kwargs.pop("class_", None) or ""
+    kwargs["class_"] = f"querychat {user_class}".strip()
+    return kwargs
+
+
+def _querychat_head_content():
+    css_path = Path(__file__).parent / "static" / "css" / "styles.css"
+    js_path = Path(__file__).parent / "static" / "js" / "querychat.js"
+    return ui.head_content(
+        ui.include_css(css_path),
+        ui.include_js(js_path),
     )
 
 

--- a/pkg-py/src/querychat/static/css/handoff.css
+++ b/pkg-py/src/querychat/static/css/handoff.css
@@ -142,6 +142,12 @@
   padding: 0;
 }
 
+/* shinychat re-adopts the chat footer into its React tree at page load, which
+   double-initializes this editor; the live instance is the last one. */
+.querychat-handoff-panel-body .code-editor > *:not(:last-child) {
+  display: none;
+}
+
 .querychat-handoff-panel-body .ace_editor {
   height: 100% !important;
 }

--- a/pkg-py/src/querychat/static/css/styles.css
+++ b/pkg-py/src/querychat/static/css/styles.css
@@ -1,3 +1,4 @@
+/* Generated file. Source: js/src/styles.css. Do not edit directly. */
 .querychat shiny-chat-message table td,
 .querychat shiny-chat-message table th {
   border: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color);
@@ -12,4 +13,10 @@
 .bslib-sidebar-layout:has(.querychat-sidebar):not(.sidebar-collapsed)>.collapse-toggle {
     right: 4px;
     top: 4px;
+}
+
+/* Collapse footer padding when it holds only querychat's inert extras.
+   Target the class: shinychat re-renders footer content into this div. */
+.shiny-chat-footer:has(> .querychat-extras:only-child) {
+    padding: 0 0 var(--shiny-chat-input-padding-bottom, var(--_chat-container-padding, .25rem));
 }

--- a/pkg-py/src/querychat/static/css/styles.css
+++ b/pkg-py/src/querychat/static/css/styles.css
@@ -20,3 +20,10 @@
 .shiny-chat-footer:has(> .querychat-extras:only-child) {
     padding: 0 0 var(--shiny-chat-input-padding-bottom, var(--_chat-container-padding, .25rem));
 }
+
+/* The footer centers its own content (the message composer); reset that for
+   querychat's extras so the handoff panel and other footer-injected UI don't
+   inherit center alignment. */
+.querychat-extras {
+    text-align: left;
+}

--- a/pkg-py/tests/playwright/test_13_handoff.py
+++ b/pkg-py/tests/playwright/test_13_handoff.py
@@ -280,7 +280,7 @@ class TestHandoffGeneration(HandoffModalActions):
         textarea.fill("Add a comment at the top that says BROWSER_HISTORY.")
         textarea.press("Enter")
 
-        editor = self.page.locator(".querychat-handoff-panel-body textarea")
+        editor = self.page.locator(".querychat-handoff-panel-body textarea:visible")
         expect(editor).to_have_value(re.compile("BROWSER_HISTORY"), timeout=120000)
 
     def test_generated_handoff_can_be_closed_and_reopened(self):
@@ -288,7 +288,7 @@ class TestHandoffGeneration(HandoffModalActions):
 
         panel = self.page.locator(".querychat-handoff-panel")
         expect(panel).to_have_class(re.compile(r"\bopen\b"), timeout=60000)
-        editor = self.page.locator(".querychat-handoff-panel-body textarea")
+        editor = self.page.locator(".querychat-handoff-panel-body textarea:visible")
         expect(editor).to_be_visible(timeout=60000)
         expect(editor).not_to_have_value("", timeout=120000)
         pill = self.page.locator(".querychat-handoff-pill")
@@ -319,7 +319,7 @@ class TestHandoffGeneration(HandoffModalActions):
         expect(pill.first).to_be_visible(timeout=30000)
         pill.first.click()
 
-        editor = self.page.locator(".querychat-handoff-panel-body textarea")
+        editor = self.page.locator(".querychat-handoff-panel-body textarea:visible")
         expect(editor).to_have_value(re.compile("BROWSER_HISTORY"), timeout=10000)
 
 
@@ -379,6 +379,6 @@ class TestHandoffPlainBookmarkRestore(HandoffModalActions):
 
         restored_panel = new_page.locator(".querychat-handoff-panel")
         expect(restored_panel).to_have_class(re.compile(r"\bopen\b"), timeout=5000)
-        editor = restored_panel.locator(".querychat-handoff-panel-body textarea")
+        editor = restored_panel.locator(".querychat-handoff-panel-body textarea:visible")
         expect(editor).not_to_have_value("", timeout=10000)
         new_page.close()

--- a/pkg-py/tests/test_shiny_module.py
+++ b/pkg-py/tests/test_shiny_module.py
@@ -31,13 +31,13 @@ def _fake_chat_ui(*args, **kwargs):
 _fake_chat_ui.last_kwargs: dict = {}
 
 
-def test_mod_ui_enables_attachments_by_default():
-    """mod_ui() should pass allow_attachments=True to shinychat.chat_ui by default."""
+def test_mod_ui_defers_attachments_default_to_shinychat():
+    """mod_ui() omits allow_attachments so shinychat's client=-based auto-enable applies."""
     from querychat._shiny_module import mod_ui
 
     with patch("querychat._shiny_module.shinychat.chat_ui", side_effect=_fake_chat_ui):
         mod_ui("test")  # id is required — @module.ui injects it as first positional arg
-        assert _fake_chat_ui.last_kwargs.get("allow_attachments") is True
+        assert "allow_attachments" not in _fake_chat_ui.last_kwargs
 
 
 def test_mod_ui_allow_attachments_can_be_overridden():
@@ -50,15 +50,24 @@ def test_mod_ui_allow_attachments_can_be_overridden():
 
 
 def test_mod_ui_scopes_handoff_roots_and_deduplicates_assets():
+    # Uses the real shinychat.chat_ui: the handoff panel and dependencies ride
+    # inside chat_ui(footer=), so a fake chat_ui would swallow them.
     from querychat._shiny_module import mod_ui
 
-    with patch("querychat._shiny_module.shinychat.chat_ui", side_effect=_fake_chat_ui):
-        rendered = TagList(mod_ui("first"), mod_ui("second")).render()
+    rendered = TagList(mod_ui("first"), mod_ui("second")).render()
 
     assert 'id="first-handoff_root"' in rendered["html"]
     assert 'id="second-handoff_root"' in rendered["html"]
     dependency_names = [dependency.name for dependency in rendered["dependencies"]]
     assert dependency_names.count("querychat-handoff") == 1
+
+
+def test_mod_ui_injects_extras_via_footer_and_merges_user_footer():
+    from querychat._shiny_module import mod_ui
+
+    html = str(mod_ui("test", footer=ui.div(id="my-footer")))
+    assert 'id="my-footer"' in html
+    assert "querychat-extras" in html
 
 
 def _unwrap_module_server(decorated):

--- a/pkg-py/tests/test_shiny_module.py
+++ b/pkg-py/tests/test_shiny_module.py
@@ -32,7 +32,7 @@ _fake_chat_ui.last_kwargs: dict = {}
 
 
 def test_mod_ui_defers_attachments_default_to_shinychat():
-    """mod_ui() omits allow_attachments so shinychat's client=-based auto-enable applies."""
+    """mod_ui() omits allow_attachments so shinychat's client-based auto-enable applies."""
     from querychat._shiny_module import mod_ui
 
     with patch("querychat._shiny_module.shinychat.chat_ui", side_effect=_fake_chat_ui):

--- a/pkg-r/DESCRIPTION
+++ b/pkg-r/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     R6,
     rlang (>= 1.1.0),
     S7,
-    shiny,
+    shiny (>= 1.14.0),
     shinychat (> 0.4.0),
     utils,
     whisker,

--- a/pkg-r/R/querychat_module.R
+++ b/pkg-r/R/querychat_module.R
@@ -1,17 +1,34 @@
 # Main module UI function
 mod_ui <- function(id, ...) {
   ns <- shiny::NS(id)
-  htmltools::tagList(
+  dots <- add_footer_and_class(rlang::list2(...), ns)
+  rlang::exec(
+    shinychat::chat_ui,
+    ns("chat"),
+    height = "100%",
+    !!!dots
+  )
+}
+
+add_footer_and_class <- function(dots, ns) {
+  dots$class <- paste(c("querychat", dots$class), collapse = " ")
+  dots$footer <- querychat_footer(dots$footer, ns)
+  dots
+}
+
+# The footer is the only child-injection point in chat_ui()/page_chat();
+# styles.css collapses it when it holds only these extras.
+querychat_footer <- function(user_footer = NULL, ns) {
+  extras <- htmltools::tags$div(
+    class = "querychat-extras",
     querychat_dependency(),
     handoff_html_dependency(),
-    shinychat::chat_ui(
-      ns("chat"),
-      height = "100%",
-      class = "querychat",
-      ...
-    ),
     handoff_panel_ui(ns)
   )
+  if (is.null(user_footer)) {
+    return(extras)
+  }
+  htmltools::tagList(user_footer, extras)
 }
 
 querychat_dependency <- function() {

--- a/pkg-r/inst/htmldep/handoff.css
+++ b/pkg-r/inst/htmldep/handoff.css
@@ -142,6 +142,12 @@
   padding: 0;
 }
 
+/* shinychat re-adopts the chat footer into its React tree at page load, which
+   double-initializes this editor; the live instance is the last one. */
+.querychat-handoff-panel-body .code-editor > *:not(:last-child) {
+  display: none;
+}
+
 .querychat-handoff-panel-body .ace_editor {
   height: 100% !important;
 }

--- a/pkg-r/inst/htmldep/styles.css
+++ b/pkg-r/inst/htmldep/styles.css
@@ -20,3 +20,10 @@
 .shiny-chat-footer:has(> .querychat-extras:only-child) {
     padding: 0 0 var(--shiny-chat-input-padding-bottom, var(--_chat-container-padding, .25rem));
 }
+
+/* The footer centers its own content (the message composer); reset that for
+   querychat's extras so the handoff panel and other footer-injected UI don't
+   inherit center alignment. */
+.querychat-extras {
+    text-align: left;
+}

--- a/pkg-r/tests/testthat/test-querychat_module.R
+++ b/pkg-r/tests/testthat/test-querychat_module.R
@@ -311,20 +311,23 @@ test_that("mod_ui() passes enable_cancel through to chat_ui without warning", {
 
 describe("mod_ui()", {
   it("mounts both dependencies and one closed namespaced handoff panel", {
-    local_mocked_bindings(
-      chat_ui = function(id, ...) {
-        htmltools::div(id = id, class = "mock-chat")
-      },
-      .package = "shinychat"
-    )
-
+    # Uses the real chat_ui: dependencies and the handoff panel ride inside
+    # chat_ui(footer=), so a mock would swallow them.
     ui <- mod_ui("module")
     markup <- as.character(ui)
 
-    expect_identical(ui[[1]]$name, "querychat")
-    expect_identical(ui[[2]]$name, "querychat-handoff")
-    expect_identical(ui[[2]]$script, "handoff.js")
-    expect_identical(ui[[2]]$stylesheet, "handoff.css")
+    deps <- htmltools::findDependencies(ui)
+    dep_names <- vapply(deps, `[[`, "", "name")
+    expect_true("querychat" %in% dep_names)
+    expect_true("querychat-handoff" %in% dep_names)
+    handoff_dep <- deps[[which(dep_names == "querychat-handoff")]]
+    expect_identical(handoff_dep$script, "handoff.js")
+    expect_identical(handoff_dep$stylesheet, "handoff.css")
+
+    # The extras are attached inside the chat root via the footer slot
+    expect_match(markup, "shiny-chat-footer", fixed = TRUE)
+    expect_match(markup, "querychat-extras", fixed = TRUE)
+
     expect_identical(
       lengths(regmatches(
         markup,


### PR DESCRIPTION
## Why

`mod_ui()` (R and Python) previously delivered querychat's dependencies and the handoff panel as `tagList()` siblings of `chat_ui()`. This routes them through shinychat's `footer` slot instead — the only child-injection point `page_chat()` accepts — so extras injection works uniformly across chat entry points. This is groundwork for a forthcoming `page()`/`$page()` method (stacked PR to follow).

## What changes

- `mod_ui()` builds the extras (dependencies + handoff panel) into a `.querychat-extras` wrapper in the chat footer, merging any user-supplied `footer` and `class`.
- `enable_cancel`/`allow_attachments` defaults are deferred to shinychat's client-based auto-enable.
- `styles.css` source moves to `js/src/`; new rule collapses footer padding when it holds only the inert extras.
- **Bug fix:** shinychat re-adopts the footer into its React tree at page load, which races `<bslib-code-editor>`'s async init and leaves a second, stale editor instance in the handoff panel. All but the last (live) instance are hidden via CSS; handoff E2E selectors are scoped to `:visible`.

## Test plan

- Python unit tests (875) and R testthat files pass
- Full handoff Playwright suite (21 tests) passes, including the editor reopen/restore flows

### Also on this branch

- Bumps the R shiny requirement to >= 1.14.0: its per-output ResizeObserver/IntersectionObserver visibility tracking is needed for querychat UI living in shinychat chrome (footer extras here; the auto-opening data drawer in the stacked drawer-app PR).
