### PR TITLE
fix(r): stop the query tool from over-expanding results

### DIFF
--- a/pkg-r/NEWS.md
+++ b/pkg-r/NEWS.md
@@ -55,7 +55,7 @@
 
 ## Bug fixes
 
-* The `querychat_query` tool's `collapsed` argument description no longer tells the LLM to expand a result whenever it's "the primary answer" — a bar nearly every query cleared, causing results to be shown expanded (and then often repeated in the response text) far more often than intended. It now matches the Python implementation's guidance: expand only when the user explicitly asks to see the raw table. (#295)
+* Query results were being shown expanded, and often repeated in the LLM's response, far more often than intended. The LLM is now guided to expand a result only when the user explicitly asks to see the raw table. (#295)
 
 # querychat 0.3.0
 

--- a/pkg-r/NEWS.md
+++ b/pkg-r/NEWS.md
@@ -53,6 +53,10 @@
 
 * The close button in `$app()` is now hidden when running in a non-interactive context (e.g. a deployed Shiny app), preventing `stopApp()` from crashing the session for other users. (#259)
 
+## Bug fixes
+
+* The `querychat_query` tool's `collapsed` argument description no longer tells the LLM to expand a result whenever it's "the primary answer" — a bar nearly every query cleared, causing results to be shown expanded (and then often repeated in the response text) far more often than intended. It now matches the Python implementation's guidance: expand only when the user explicitly asks to see the raw table. (#295)
+
 # querychat 0.3.0
 
 ## New features

--- a/pkg-r/R/querychat_tools.R
+++ b/pkg-r/R/querychat_tools.R
@@ -196,7 +196,7 @@ tool_query <- function(executor, multi_table = FALSE) {
         )
       ),
       collapsed = ellmer::type_boolean(
-        "Optional (default: true). The result card starts collapsed by default; the user can expand it to see the query and results. Set to false when the query result table is the primary answer to the user's question and should be immediately visible without expanding.",
+        "Optional. If omitted, visibility follows the app-configured default behavior (typically collapsed). If you are unsure, omit this parameter. If you provide it explicitly, prefer true. Set to false only when the user explicitly asks to see the raw table immediately.",
         required = FALSE
       ),
       `_intent` = ellmer::type_string(


### PR DESCRIPTION
## Summary

Query results in R demos were routinely shown expanded in the chat UI, and the LLM would then also restate the same table in its response text — noisy, duplicated output.

The root cause was a parity gap: PR #248 tightened the `collapsed` argument guidance on the Python side (both the docstring and shared `tool-query.md` prompt) so the LLM only expands a result when the user explicitly asks to see it, but the equivalent argument description in the R tool (`pkg-r/R/querychat_tools.R`) was never updated. It still told the model to expand whenever "the query result table is the primary answer to the user's question" — which is true for nearly every query in a typical demo, so the model expanded almost every result by default.

This brings the R argument description in line with what Python already says, so `collapsed=false` is reserved for cases where the user actually asks to see the raw table.

## Test plan
- [x] `make r-check-format`
- [x] `make r-check-tests` (0 failures, pre-existing unrelated warnings only)