### PR TITLE
fix(r): default handoff language selector to R, listed before Python

### DIFF
--- a/pkg-r/R/handoff_ui.R
+++ b/pkg-r/R/handoff_ui.R
@@ -351,7 +351,7 @@ handoff_type_selector_ui <- function() {
 }
 
 handoff_language_selector_ui <- function(ns) {
-  languages <- c(python = "Python", r = "R")
+  languages <- c(r = "R", python = "Python")
   radios <- Map(
     function(language, label) {
       htmltools::tags$label(
@@ -360,7 +360,7 @@ handoff_language_selector_ui <- function(ns) {
           name = ns("handoff_language"),
           class = "querychat-handoff-language-radio",
           `data-language` = language,
-          checked = if (language == "python") "" else NULL
+          checked = if (language == "r") "" else NULL
         ),
         htmltools::tags$span(
           class = paste(

--- a/pkg-r/tests/testthat/_snaps/handoff_ui.md
+++ b/pkg-r/tests/testthat/_snaps/handoff_ui.md
@@ -129,15 +129,15 @@
                 </bslib-tooltip>
               </div>
               <div class="querychat-handoff-language-selector" role="radiogroup" aria-label="Programming language">
-                <label class="querychat-handoff-language-option querychat-handoff-language-pill" data-language="python">
-                  <input type="radio" name="module-handoff_language" class="querychat-handoff-language-radio" data-language="python" checked=""/>
-                  <span class="querychat-handoff-language-icon querychat-handoff-language-icon-python"></span>
-                  Python
-                </label>
                 <label class="querychat-handoff-language-option querychat-handoff-language-pill" data-language="r">
-                  <input type="radio" name="module-handoff_language" class="querychat-handoff-language-radio" data-language="r"/>
+                  <input type="radio" name="module-handoff_language" class="querychat-handoff-language-radio" data-language="r" checked=""/>
                   <span class="querychat-handoff-language-icon querychat-handoff-language-icon-r"></span>
                   R
+                </label>
+                <label class="querychat-handoff-language-option querychat-handoff-language-pill" data-language="python">
+                  <input type="radio" name="module-handoff_language" class="querychat-handoff-language-radio" data-language="python"/>
+                  <span class="querychat-handoff-language-icon querychat-handoff-language-icon-python"></span>
+                  Python
                 </label>
               </div>
               <div class="querychat-handoff-section-label-row mt-2">
@@ -273,15 +273,15 @@
                 </bslib-tooltip>
               </div>
               <div class="querychat-handoff-language-selector" role="radiogroup" aria-label="Programming language">
-                <label class="querychat-handoff-language-option querychat-handoff-language-pill" data-language="python">
-                  <input type="radio" name="module-handoff_language" class="querychat-handoff-language-radio" data-language="python" checked=""/>
-                  <span class="querychat-handoff-language-icon querychat-handoff-language-icon-python"></span>
-                  Python
-                </label>
                 <label class="querychat-handoff-language-option querychat-handoff-language-pill" data-language="r">
-                  <input type="radio" name="module-handoff_language" class="querychat-handoff-language-radio" data-language="r"/>
+                  <input type="radio" name="module-handoff_language" class="querychat-handoff-language-radio" data-language="r" checked=""/>
                   <span class="querychat-handoff-language-icon querychat-handoff-language-icon-r"></span>
                   R
+                </label>
+                <label class="querychat-handoff-language-option querychat-handoff-language-pill" data-language="python">
+                  <input type="radio" name="module-handoff_language" class="querychat-handoff-language-radio" data-language="python"/>
+                  <span class="querychat-handoff-language-icon querychat-handoff-language-icon-python"></span>
+                  Python
                 </label>
               </div>
               <div class="querychat-handoff-section-label-row mt-2">

--- a/pkg-r/tests/testthat/test-handoff_ui.R
+++ b/pkg-r/tests/testthat/test-handoff_ui.R
@@ -86,6 +86,25 @@ describe("handoff_modal_ui()", {
     expect_match(markup, 'data-languages="python,r"', fixed = TRUE)
   })
 
+  it("defaults the language selector to R, listed before Python", {
+    modal <- handoff_modal_ui(ns, list())
+    markup <- as.character(modal)
+
+    r_radio_pos <- regexpr(
+      '<input[^>]*data-language="r"[^>]*checked=""',
+      markup
+    )
+    python_radio_pos <- regexpr(
+      '<input[^>]*data-language="python"(?!.*checked)',
+      markup,
+      perl = TRUE
+    )
+
+    expect_true(r_radio_pos > 0)
+    expect_true(python_radio_pos > 0)
+    expect_true(r_radio_pos < python_radio_pos)
+  })
+
   it("renders gallery item attributes and escapes their titles", {
     unsafe_title <- '<script>alert("x")</script> & report'
     items <- list(


### PR DESCRIPTION
## Summary
- The R package's "Prepare Handoff" modal previously defaulted to Python and listed it before R. For R users, that's backwards — the language selector now defaults to R and lists it first, with Python second.

## Test plan
- [x] Updated/added R unit test asserting R is checked by default and rendered before Python (`pkg-r/tests/testthat/test-handoff_ui.R`)
- [x] Full R test suite passes (`devtools::test()`, 2070 passed / 0 failed)
- [x] `air format --check` passes
- [x] Verified visually in a real browser (R hello-app example, `/handoff` slash command) that the modal shows R selected and listed first, Python second

🤖 Generated with [Claude Code](https://claude.com/claude-code)