### PR TITLE
fix(py): stop viz preload from adding phantom scroll to sidebar

### DIFF
--- a/pkg-py/CHANGELOG.md
+++ b/pkg-py/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The `"visualize"` tool is now included in the default toolset (`tools=("filter", "query", "visualize")`). If the visualization dependencies are not installed (the `viz` extra), the tool is dropped with a warning instead of raising an `ImportError`.
 
+### Bug fixes
+
+* Fixed a phantom scrollbar on scrollable ancestors of the chat (e.g. a bslib sidebar created with `qc.sidebar()`): the hidden visualization preload widget is much taller than its 1px container, and its unclipped overflow leaked into the ancestor's scrollable region, letting it scroll past the chat's bottom edge.
+
 ## [0.7.0] - 2026-07-10
 
 ### New features

--- a/pkg-py/src/querychat/_viz_utils.py
+++ b/pkg-py/src/querychat/_viz_utils.py
@@ -35,10 +35,8 @@ def preload_viz_deps_ui():
         class_="querychat-viz-preload",
         hidden="",
         aria_hidden="true",
-        # overflow:clip keeps the (much taller) preloaded widget from leaking
-        # scrollable overflow into ancestors. Without it, an overflow:auto
-        # ancestor (e.g. a bslib sidebar hosting the chat) gains a phantom
-        # scrollbar and can scroll past the chat's bottom edge.
+        # Clip so the full-height widget can't leak scrollable overflow into
+        # scrollable ancestors (e.g. a sidebar hosting the chat).
         style="position:absolute; left:-9999px; width:1px; height:1px; overflow:clip;",
     )
 

--- a/pkg-py/src/querychat/_viz_utils.py
+++ b/pkg-py/src/querychat/_viz_utils.py
@@ -35,7 +35,11 @@ def preload_viz_deps_ui():
         class_="querychat-viz-preload",
         hidden="",
         aria_hidden="true",
-        style="position:absolute; left:-9999px; width:1px; height:1px;",
+        # overflow:clip keeps the (much taller) preloaded widget from leaking
+        # scrollable overflow into ancestors. Without it, an overflow:auto
+        # ancestor (e.g. a bslib sidebar hosting the chat) gains a phantom
+        # scrollbar and can scroll past the chat's bottom edge.
+        style="position:absolute; left:-9999px; width:1px; height:1px; overflow:clip;",
     )
 
 

--- a/pkg-py/tests/test_viz_footer.py
+++ b/pkg-py/tests/test_viz_footer.py
@@ -123,6 +123,16 @@ class TestVizPreloadMarkup:
         assert "<script" not in rendered["html"]
         assert preload_dep.script == [{"src": "js/viz-preload.js"}]
 
+    def test_preload_markup_clips_widget_overflow(self):
+        # The preload box is 1px but hosts a full-size widget. Without
+        # overflow:clip, the widget's box leaks scrollable overflow into
+        # ancestors, giving an overflow:auto ancestor (e.g. a bslib sidebar
+        # hosting the chat) a phantom scrollbar that scrolls past the chat.
+        from querychat._viz_utils import preload_viz_deps_ui
+
+        rendered = TagList(preload_viz_deps_ui()).render()
+        assert "overflow:clip" in rendered["html"]
+
 
 class TestVizFooterDomIds:
     def test_build_viz_footer_uses_resolved_dom_widget_id(self):

--- a/pkg-py/tests/test_viz_footer.py
+++ b/pkg-py/tests/test_viz_footer.py
@@ -124,10 +124,8 @@ class TestVizPreloadMarkup:
         assert preload_dep.script == [{"src": "js/viz-preload.js"}]
 
     def test_preload_markup_clips_widget_overflow(self):
-        # The preload box is 1px but hosts a full-size widget. Without
-        # overflow:clip, the widget's box leaks scrollable overflow into
-        # ancestors, giving an overflow:auto ancestor (e.g. a bslib sidebar
-        # hosting the chat) a phantom scrollbar that scrolls past the chat.
+        # The 1px preload box hosts a full-height widget; without clipping,
+        # it leaks scrollable overflow into scrollable ancestors.
         from querychat._viz_utils import preload_viz_deps_ui
 
         rendered = TagList(preload_viz_deps_ui()).render()


### PR DESCRIPTION
## Summary

`.querychat-viz-preload` — the 1px offscreen box that warm-loads the Altair/ipywidgets JS deps — didn't clip its ~400px widget child. With every ancestor up through the chat container being `overflow: visible`, the widget's box leaked into the scrollable overflow region of the first scrollable ancestor (e.g. the `overflow: auto` sidebar from `qc.sidebar()`), giving it a phantom scrollbar that scrolls a few hundred pixels past the chat's bottom edge. Python-only: pkg-r has no preload mechanism.

## Fix

`overflow: clip` on the preload element's inline style, plus a regression test and changelog entry. Clipping doesn't resize or disturb the widget; it just stops the leak.

## Verification

- Reproduced live in an app with the chat in a `page_navbar(fillable=True)` sidebar: sidebar scrollable overflow went from ~376px to 0, and the chat's internal message scrolling is unaffected.
- `make py-check-tests` (898 passed), `ruff check`, and `pyright` all clean.