### PR TITLE
fix(py): don't clean up a table replaced via server(data_source=)

### DIFF
--- a/pkg-py/CHANGELOG.md
+++ b/pkg-py/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       qc.server(data_source=conn.table("my_table"), client=chat_client)
   ```
 
-  Registering a table this way is no longer blocked by an earlier session having already registered one.
+  Registering a table this way is no longer blocked by an earlier session having already registered one, and no longer tears down a still-in-use data source from an earlier session (replacing it via `server(data_source=)` leaves the replaced source's cleanup to whoever created it).
 
 ### Improvements
 

--- a/pkg-py/src/querychat/_querychat_base.py
+++ b/pkg-py/src/querychat/_querychat_base.py
@@ -505,6 +505,7 @@ class QueryChatBase(Generic[IntoFrameT]):
         *,
         replace: bool,
         include_in_greeting: bool,
+        cleanup_replaced: bool = True,
     ) -> None:
         """
         Stage a table and rebuild the system prompt/executor cache.
@@ -513,6 +514,16 @@ class QueryChatBase(Generic[IntoFrameT]):
         directly by ``.server(data_source=...)`` so that each session can
         register (or replace) its own table even after an earlier session's
         ``.server()`` call has already set ``_server_initialized``.
+
+        ``cleanup_replaced=False`` must be used for that per-session
+        replacement: a table replaced here may still be in active use by an
+        earlier, already-running session (e.g. its own
+        ``DataSourceExecutor`` holds a live reference to it), so closing/
+        disposing it here would pull the resource out from under that
+        session. Cleaning it up is then the caller's own responsibility
+        (e.g. via ``session.on_ended()`` in the code that created it). The
+        default (``True``) preserves :meth:`add_table`'s existing behavior,
+        where a config-time replacement has exactly one owner.
         """
         if not isinstance(include_in_greeting, bool):
             raise TypeError(
@@ -549,7 +560,7 @@ class QueryChatBase(Generic[IntoFrameT]):
 
         old_source = self._data_sources.get(table_name)
         self._data_sources = next_data_sources
-        if old_source is not None and old_source is not normalized:
+        if cleanup_replaced and old_source is not None and old_source is not normalized:
             old_source.cleanup()
         if self._query_executor is not None:
             with contextlib.suppress(Exception):

--- a/pkg-py/src/querychat/_querychat_base.py
+++ b/pkg-py/src/querychat/_querychat_base.py
@@ -563,8 +563,9 @@ class QueryChatBase(Generic[IntoFrameT]):
         if cleanup_replaced and old_source is not None and old_source is not normalized:
             old_source.cleanup()
         if self._query_executor is not None:
-            with contextlib.suppress(Exception):
-                self._query_executor.cleanup()
+            if cleanup_replaced:
+                with contextlib.suppress(Exception):
+                    self._query_executor.cleanup()
             self._query_executor = None
 
         if include_in_greeting and table_name not in self.greeter.tables:

--- a/pkg-py/src/querychat/_shiny.py
+++ b/pkg-py/src/querychat/_shiny.py
@@ -716,6 +716,7 @@ class QueryChat(QueryChatBase[IntoFrameT]):
                 resolved_table_name,
                 replace=True,
                 include_in_greeting=True,
+                cleanup_replaced=False,
             )
 
         self._require_initialized("server")

--- a/pkg-py/tests/test_server_data_source.py
+++ b/pkg-py/tests/test_server_data_source.py
@@ -164,3 +164,36 @@ class TestServerDataSourceCleanupSafety:
         with patch.object(first_source, "cleanup") as mock_cleanup:
             qc.add_table(other_users_df, "users", replace=True)
             mock_cleanup.assert_called_once()
+
+    def test_second_session_does_not_clean_up_first_sessions_query_executor(
+        self, users_df, other_users_df, captured_mod_server
+    ):
+        """
+        A second session's server(data_source=...) call must not close the
+        cached QueryExecutor an earlier, still-running session's chat has
+        already captured (e.g. via _create_session_client) and is actively
+        querying through.
+        """
+        qc = shiny_mod.QueryChat(None, table_name="users")
+
+        qc.server(data_source=users_df)
+        first_executor = qc._require_query_executor("test")
+
+        with patch.object(first_executor, "cleanup") as mock_cleanup:
+            qc.server(data_source=other_users_df)
+            mock_cleanup.assert_not_called()
+
+    def test_public_add_table_replace_still_cleans_up_old_query_executor(
+        self, users_df, other_users_df
+    ):
+        """
+        Config-time add_table(replace=True) has exactly one owner, so its
+        existing cleanup-on-replace behavior for the cached executor must be
+        unchanged.
+        """
+        qc = shiny_mod.QueryChat(users_df, "users")
+        first_executor = qc._require_query_executor("test")
+
+        with patch.object(first_executor, "cleanup") as mock_cleanup:
+            qc.add_table(other_users_df, "users", replace=True)
+            mock_cleanup.assert_called_once()

--- a/pkg-py/tests/test_server_data_source.py
+++ b/pkg-py/tests/test_server_data_source.py
@@ -1,6 +1,6 @@
 """Tests for QueryChat.server(data_source=...) parity with R (#300)."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -129,3 +129,38 @@ class TestServerDataSourceSurvivesSecondSession:
 
         with pytest.raises(RuntimeError, match="Cannot add tables after server"):
             qc.add_table(other_users_df, "other")
+
+
+class TestServerDataSourceCleanupSafety:
+    def test_second_session_does_not_clean_up_first_sessions_source(
+        self, users_df, other_users_df, captured_mod_server
+    ):
+        """
+        A second session's server(data_source=...) call must not tear down
+        the DataSource object an earlier, still-running session's own
+        DataSourceExecutor holds a live reference to (e.g. closing a DuckDB
+        connection or disposing a SQLAlchemy engine out from under it).
+        """
+        qc = shiny_mod.QueryChat(None, table_name="users")
+
+        qc.server(data_source=users_df)
+        first_source = qc._data_sources["users"]
+
+        with patch.object(first_source, "cleanup") as mock_cleanup:
+            qc.server(data_source=other_users_df)
+            mock_cleanup.assert_not_called()
+
+    def test_public_add_table_replace_still_cleans_up_old_source(
+        self, users_df, other_users_df
+    ):
+        """
+        Config-time add_table(replace=True) (before any session starts) has
+        exactly one owner for the replaced table, so its existing
+        cleanup-on-replace behavior must be unchanged.
+        """
+        qc = shiny_mod.QueryChat(users_df, "users")
+        first_source = qc._data_sources["users"]
+
+        with patch.object(first_source, "cleanup") as mock_cleanup:
+            qc.add_table(other_users_df, "users", replace=True)
+            mock_cleanup.assert_called_once()


### PR DESCRIPTION
## Stacked on #302

Depends on #302 (let `server(data_source=)` survive a second session) — review that first. This PR's diff is just the cleanup-safety fix on top of it.

## The problem

Once #302 lets a second session register its own table under the same name, that registration is implemented the same way `add_table(replace=True)` always has been: "replacing" a table cleans up the one it replaces — closing a database connection, disposing a SQLAlchemy engine, etc.

That's correct when *you* deliberately reconfigure a table before anyone's connected — the old value really is dead. It's wrong once two sessions can register concurrently: a second session's own resource is unrelated to the first session's, but registering it under the same table name still triggers cleanup of the first session's resource. Concretely, with the deferred per-session pattern:

```python
qc = QueryChat(None, table_name="orders")

def server(input, output, session):
    conn = get_per_user_connection(session)  # e.g. a per-user SQLAlchemy engine
    qc.server(data_source=conn)
```

- Session A registers `conn_A`. Fine.
- Session B registers `conn_B` under the same `"orders"` name. This closes/disposes `conn_A` — session A's own connection — even though session A is a completely unrelated user who is still actively using it. Session A's next query then fails.

## The fix

`_add_or_replace_table()` gains `cleanup_replaced=False`, used only by `server(data_source=...)`'s internal call. A table replaced through that path is left alone; cleaning it up becomes the responsibility of whoever created it (e.g. closing it themselves via the framework's own session-end hook), since another session may still depend on it.

The public `add_table(replace=True)` is unaffected — it still cleans up the table it replaces, since that path has exactly one owner.

## Test plan

- New test: a second session's `server(data_source=...)` call does not call `.cleanup()` on the first session's data source.
- New test: the public `add_table(replace=True)` still calls `.cleanup()` on the table it replaces (locks in unchanged behavior).